### PR TITLE
Polish TUI layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@ node_modules
 dist
 coverage
 .DS_Store
+.env
+.env.*
+.eslintcache
+*.log

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Box, Text, useInput, useApp } from 'ink';
+import { Box, Text, useInput, useApp, useStdout } from 'ink';
 import { Header } from './components/Header.js';
 import { Footer } from './components/Footer.js';
 import { FileList } from './components/FileList.js';
@@ -25,6 +25,8 @@ enum ViewState {
 
 export const App: React.FC<AppProps> = ({ startPath, themeName: initialThemeName, units: initialUnits }) => {
   const { exit } = useApp();
+  const { stdout } = useStdout();
+  const [totalRows, setTotalRows] = useState(() => stdout?.rows ?? process.stdout.rows ?? 24);
 
   // Determine initial theme: CLI arg > Config > Default
   const configTheme = getThemeFromConfig();
@@ -42,11 +44,15 @@ export const App: React.FC<AppProps> = ({ startPath, themeName: initialThemeName
   const [rootNode, setRootNode] = useState<FileNode | null>(null);
   const [showConfirmDelete, setShowConfirmDelete] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [spinnerIndex, setSpinnerIndex] = useState(0);
+  const spinnerFrames = ['|', '/', '-', '\\'];
 
   const {
     currentNode,
     files,
     selectionIndex,
+    sortBy,
+    sortOrder,
     moveSelection,
     enterDirectory,
     goUp,
@@ -68,6 +74,32 @@ export const App: React.FC<AppProps> = ({ startPath, themeName: initialThemeName
     };
     runScan();
   }, [startPath]);
+
+  useEffect(() => {
+    if (!loading) return;
+    const timer = setInterval(() => {
+      setSpinnerIndex((prev) => (prev + 1) % spinnerFrames.length);
+    }, 120);
+
+    return () => clearInterval(timer);
+  }, [loading]);
+
+  useEffect(() => {
+    const updateRows = () => {
+      setTotalRows(stdout?.rows ?? process.stdout.rows ?? 24);
+    };
+
+    updateRows();
+    const immediateTimer = setTimeout(updateRows, 0);
+    const settleTimer = setTimeout(updateRows, 100);
+    stdout?.on('resize', updateRows);
+
+    return () => {
+      stdout?.off('resize', updateRows);
+      clearTimeout(immediateTimer);
+      clearTimeout(settleTimer);
+    };
+  }, [stdout]);
 
   useInput((input, key) => {
     if (loading) return;
@@ -125,41 +157,60 @@ export const App: React.FC<AppProps> = ({ startPath, themeName: initialThemeName
   });
 
   if (error) {
-    return <Text color="red">Error: {error}</Text>;
+    return (
+      <Box height={totalRows} width="100%">
+        <Text color="red">Error: {error}</Text>
+      </Box>
+    );
   }
 
   if (loading || !currentNode) {
-    return <Text color={theme.colours.text}>Scanning {startPath}...</Text>;
+    return (
+      <Box height={totalRows} width="100%">
+        <Text color={theme.colours.text}>
+          Scanning {startPath}... {spinnerFrames[spinnerIndex]}
+        </Text>
+      </Box>
+    );
   }
 
   if (view === ViewState.Settings) {
     return (
-      <Settings
-        currentTheme={currentThemeName || 'default'}
-        currentUnits={currentUnits}
-        theme={theme}
-        onSelectTheme={(name) => {
-          setCurrentThemeName(name);
-          setThemeInConfig(name);
-        }}
-        onSelectUnits={(units) => {
-          setCurrentUnits(units);
-          setUnitsInConfig(units);
-        }}
-        onBack={() => setView(ViewState.FileList)}
-      />
+      <Box height={totalRows} width="100%" justifyContent="center" alignItems="flex-start">
+        <Settings
+          currentTheme={currentThemeName || 'default'}
+          currentUnits={currentUnits}
+          theme={theme}
+          onSelectTheme={(name) => {
+            setCurrentThemeName(name);
+            setThemeInConfig(name);
+          }}
+          onSelectUnits={(units) => {
+            setCurrentUnits(units);
+            setUnitsInConfig(units);
+          }}
+          onBack={() => setView(ViewState.FileList)}
+        />
+      </Box>
     );
   }
 
   if (showConfirmDelete) {
       const selectedFile = files[selectionIndex];
       return (
-          <Box flexDirection="column" height="100%">
+          <Box flexDirection="column" height={totalRows} width="100%">
               <Header path={currentNode.path} theme={theme} />
               <Box flexGrow={1} justifyContent="center" alignItems="center">
                   <ConfirmDelete fileName={selectedFile?.name || 'item'} theme={theme} />
               </Box>
-              <Footer totalSize={currentNode.size} itemCount={files.length} theme={theme} />
+              <Footer
+                totalSize={currentNode.size}
+                itemCount={files.length}
+                theme={theme}
+                sortBy={sortBy}
+                sortOrder={sortOrder}
+                units={currentUnits}
+              />
           </Box>
       );
   }
@@ -167,7 +218,7 @@ export const App: React.FC<AppProps> = ({ startPath, themeName: initialThemeName
   const maxSize = files.reduce((max, f) => Math.max(max, f.size), 0);
 
   return (
-    <Box flexDirection="column" height="100%">
+    <Box flexDirection="column" height={totalRows} width="100%">
       <Header path={currentNode.path} theme={theme} />
 
       <Box flexGrow={1} overflowY="hidden">
@@ -180,7 +231,14 @@ export const App: React.FC<AppProps> = ({ startPath, themeName: initialThemeName
         />
       </Box>
 
-      <Footer totalSize={currentNode.size} itemCount={files.length} theme={theme} />
+      <Footer
+        totalSize={currentNode.size}
+        itemCount={files.length}
+        theme={theme}
+        sortBy={sortBy}
+        sortOrder={sortOrder}
+        units={currentUnits}
+      />
     </Box>
   );
 };

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -13,12 +13,32 @@ program
   .argument('[path]', 'Path to scan', process.cwd())
   .option('-t, --theme <theme>', 'Theme (default, dracula)')
   .option('-u, --units <units>', 'Display units (iec, si)')
+  .option('--no-fullscreen', 'Do not use alternate screen buffer')
   .action((pathStr, options) => {
     // When argument is optional and has default, pathStr is the value.
     // If user provides a path, it's in pathStr.
     // If not, it's process.cwd().
 
-    render(<App startPath={pathStr} themeName={options.theme} units={options.units} />);
+    const useFullscreen = options.fullscreen !== false;
+    const hasTty = process.stdout.isTTY;
+    const shouldUseAltBuffer = useFullscreen && hasTty;
+
+    if (shouldUseAltBuffer) {
+      process.stdout.write('\u001b[?1049h');
+    }
+
+    const instance = render(
+      <App startPath={pathStr} themeName={options.theme} units={options.units} />
+    );
+
+    if (shouldUseAltBuffer) {
+      const restoreAltBuffer = () => {
+        process.stdout.write('\u001b[?1049l');
+      };
+
+      instance.waitUntilExit().then(restoreAltBuffer);
+      process.once('exit', restoreAltBuffer);
+    }
   });
 
 program.parse(process.argv);

--- a/src/components/FileList.tsx
+++ b/src/components/FileList.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { Box, Text } from 'ink';
+import React, { useEffect, useMemo, useState } from 'react';
+import { Box, Text, useStdout } from 'ink';
 import { Theme } from '../themes.js';
 import { FileNode } from '../scanner.js';
 import { filesize } from 'filesize';
@@ -12,7 +12,14 @@ interface FileListProps {
   units: 'iec' | 'si';
 }
 
-const BAR_WIDTH = 20;
+const APP_HEADER_ROWS = 3;
+const LIST_HEADER_ROWS = 3;
+const APP_FOOTER_ROWS = 3;
+const RESERVED_ROWS = APP_HEADER_ROWS + LIST_HEADER_ROWS + APP_FOOTER_ROWS;
+const MIN_NAME_COL = 16;
+const SIZE_COL = 12;
+const PERCENT_COL = 7;
+const MIN_GRAPH_COL = 8;
 
 export const FileList: React.FC<FileListProps> = ({
   files,
@@ -21,32 +28,86 @@ export const FileList: React.FC<FileListProps> = ({
   theme,
   units,
 }) => {
-  const WINDOW_SIZE = process.stdout.rows ? process.stdout.rows - 10 : 20;
+  const { stdout } = useStdout();
+  const [totalRows, setTotalRows] = useState(() => stdout?.rows ?? process.stdout.rows ?? 24);
+  const [totalColumns, setTotalColumns] = useState(() => stdout?.columns ?? process.stdout.columns ?? 80);
+
+  useEffect(() => {
+    const updateRows = () => {
+      setTotalRows(stdout?.rows ?? process.stdout.rows ?? 24);
+      setTotalColumns(stdout?.columns ?? process.stdout.columns ?? 80);
+    };
+
+    updateRows();
+    const immediateTimer = setTimeout(updateRows, 0);
+    const settleTimer = setTimeout(updateRows, 100);
+    stdout?.on('resize', updateRows);
+
+    return () => {
+      stdout?.off('resize', updateRows);
+      clearTimeout(immediateTimer);
+      clearTimeout(settleTimer);
+    };
+  }, [stdout]);
+
+  const windowSize = Math.max(1, totalRows - RESERVED_ROWS);
+  const columnLayout = useMemo(() => {
+    const contentColumns = Math.max(0, totalColumns - 2); // paddingX=1
+    const fixedColumns = SIZE_COL + PERCENT_COL;
+    const remaining = Math.max(0, contentColumns - fixedColumns);
+
+    let graphColumns = Math.max(MIN_GRAPH_COL, Math.floor(remaining * 0.35));
+    let nameColumns = Math.max(MIN_NAME_COL, remaining - graphColumns);
+
+    if (nameColumns + graphColumns > remaining) {
+      graphColumns = Math.max(MIN_GRAPH_COL, remaining - MIN_NAME_COL);
+      nameColumns = Math.max(MIN_NAME_COL, remaining - graphColumns);
+    }
+
+    if (remaining < MIN_NAME_COL + MIN_GRAPH_COL) {
+      graphColumns = Math.max(0, remaining - MIN_NAME_COL);
+      nameColumns = remaining - graphColumns;
+    }
+
+    const showGraph = graphColumns >= 6;
+    const barWidth = Math.max(0, graphColumns - 2);
+
+    return {
+      nameColumns: Math.max(1, nameColumns),
+      sizeColumns: SIZE_COL,
+      percentColumns: PERCENT_COL,
+      graphColumns,
+      barWidth,
+      showGraph,
+    };
+  }, [totalColumns]);
 
   let start = 0;
-  if (selectedIndex >= WINDOW_SIZE / 2) {
-      start = selectedIndex - Math.floor(WINDOW_SIZE / 2);
+  if (selectedIndex >= windowSize / 2) {
+      start = selectedIndex - Math.floor(windowSize / 2);
   }
-  if (start + WINDOW_SIZE > files.length) {
-      start = Math.max(0, files.length - WINDOW_SIZE);
+  if (start + windowSize > files.length) {
+      start = Math.max(0, files.length - windowSize);
   }
 
-  const visibleFiles = files.slice(start, start + WINDOW_SIZE);
+  const visibleFiles = files.slice(start, start + windowSize);
 
   return (
     <Box flexDirection="column" width="100%">
       <Box paddingX={1} borderStyle="single">
-          <Box width="50%"><Text underline>Name</Text></Box>
-          <Box width="15%"><Text underline>Size</Text></Box>
-          <Box width="10%"><Text underline>%</Text></Box>
-          <Box><Text underline>Graph</Text></Box>
+          <Box width={columnLayout.nameColumns}><Text underline>Name</Text></Box>
+          <Box width={columnLayout.sizeColumns}><Text underline>Size</Text></Box>
+          <Box width={columnLayout.percentColumns}><Text underline>%</Text></Box>
+          {columnLayout.showGraph ? (
+            <Box width={columnLayout.graphColumns}><Text underline>Graph</Text></Box>
+          ) : null}
       </Box>
       {visibleFiles.map((file, index) => {
         const globalIndex = start + index;
         const isSelected = globalIndex === selectedIndex;
         const percentage = maxSize > 0 ? (file.size / maxSize) * 100 : 0;
-        const barFilled = Math.round((percentage / 100) * BAR_WIDTH);
-        const barEmpty = BAR_WIDTH - barFilled;
+        const barFilled = Math.round((percentage / 100) * columnLayout.barWidth);
+        const barEmpty = Math.max(0, columnLayout.barWidth - barFilled);
 
         const barStr = '#'.repeat(barFilled) + '-'.repeat(barEmpty);
 
@@ -56,7 +117,7 @@ export const FileList: React.FC<FileListProps> = ({
               width="100%"
               paddingX={1}
             >
-              <Box width="50%">
+              <Box width={columnLayout.nameColumns}>
                 <Text
                     backgroundColor={isSelected ? theme.colours.highlight : undefined}
                     color={isSelected ? theme.colours.selectedText : theme.colours.text}
@@ -66,7 +127,7 @@ export const FileList: React.FC<FileListProps> = ({
                 </Text>
               </Box>
 
-              <Box width="15%">
+              <Box width={columnLayout.sizeColumns} justifyContent="flex-end">
                   <Text
                     backgroundColor={isSelected ? theme.colours.highlight : undefined}
                     color={isSelected ? theme.colours.selectedText : theme.colours.size}
@@ -75,7 +136,7 @@ export const FileList: React.FC<FileListProps> = ({
                   </Text>
               </Box>
 
-              <Box width="10%">
+              <Box width={columnLayout.percentColumns} justifyContent="flex-end">
                   <Text
                     backgroundColor={isSelected ? theme.colours.highlight : undefined}
                     color={isSelected ? theme.colours.selectedText : theme.colours.percentage}
@@ -84,14 +145,16 @@ export const FileList: React.FC<FileListProps> = ({
                   </Text>
               </Box>
 
-              <Box>
-                <Text
-                    backgroundColor={isSelected ? theme.colours.highlight : undefined}
-                    color={isSelected ? theme.colours.selectedText : theme.colours.bar}
-                >
-                    [{barStr}]
-                </Text>
-              </Box>
+              {columnLayout.showGraph ? (
+                <Box width={columnLayout.graphColumns}>
+                  <Text
+                      backgroundColor={isSelected ? theme.colours.highlight : undefined}
+                      color={isSelected ? theme.colours.selectedText : theme.colours.bar}
+                  >
+                      [{barStr}]
+                  </Text>
+                </Box>
+              ) : null}
             </Box>
           </Box>
         );

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,32 +1,44 @@
 import React from 'react';
-import { Box, Text } from 'ink';
+import { Box, Text, useStdout } from 'ink';
 import { Theme } from '../themes.js';
-import { FileNode } from '../scanner.js';
 import { filesize } from 'filesize';
+import { SortField, SortOrder } from '../state.js';
 
 interface FooterProps {
   totalSize: number;
   itemCount: number;
   theme: Theme;
+  sortBy: SortField;
+  sortOrder: SortOrder;
+  units: 'iec' | 'si';
 }
 
-export const Footer: React.FC<FooterProps> = ({ totalSize, itemCount, theme }) => {
+export const Footer: React.FC<FooterProps> = ({ totalSize, itemCount, theme, sortBy, sortOrder, units }) => {
+  const { stdout } = useStdout();
+  const totalColumns = stdout?.columns ?? process.stdout.columns ?? 80;
+  const leftWidth = Math.max(20, Math.floor(totalColumns * 0.55));
+  const rightWidth = Math.max(20, totalColumns - leftWidth - 2);
+  const sortLabel = sortBy === 'name' ? 'Name' : 'Size';
+  const orderLabel = sortOrder === 'asc' ? 'asc' : 'desc';
+  const unitsLabel = units === 'iec' ? 'IEC' : 'SI';
+  const leftText = `Total: ${filesize(totalSize)} (${itemCount} items) | Sort: ${sortLabel} (${orderLabel}) | Units: ${unitsLabel}`;
+  const rightText = 'Delete: d | Settings: S | Quit: q | Nav: Arrows/Enter/Back';
+
   return (
     <Box
       borderStyle="single"
       borderColor={theme.colours.footer}
       paddingX={1}
       width="100%"
-      justifyContent="space-between"
     >
-      <Box>
-        <Text color={theme.colours.footer}>
-          Total: {filesize(totalSize)} ({itemCount} items)
+      <Box width={leftWidth}>
+        <Text color={theme.colours.footer} wrap="truncate-end">
+          {leftText}
         </Text>
       </Box>
-      <Box>
-        <Text color={theme.colours.footer}>
-          Delete: d | Settings: S | Quit: q | Nav: Arrows/Enter/Back
+      <Box width={rightWidth} justifyContent="flex-end">
+        <Text color={theme.colours.footer} wrap="truncate-end">
+          {rightText}
         </Text>
       </Box>
     </Box>


### PR DESCRIPTION
- Switch to alternate screen buffer by default (with `--no-fullscreen` opt‑out) to preserve scrollback and stabilise full‑screen rendering
- Make the file list layout adaptive to terminal width and right‑align numeric columns
- Add footer status for sort and units, and a lightweight scanning spinner
- Keep the app pinned to the full terminal height to avoid extra blank lines