### PR TITLE
Update docs and agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,9 @@
 - **Mandatory Testing:** Make sure the unit tests are run after changes to the code.
 - **Verification:** Always verify code changes by running relevant tests.
 
+## Documentation
+- **Updates:** When user-facing behaviour, CLI options, or features change, update `README.md` and `SPEC.md`.
+
 ## Project Structure
 - This is a TypeScript project using Ink for the CLI UI.
 - Use `pnpm` as the package manager.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SMDU (See My Disk Usage)
 
-SMDU is a modern, terminal-based disk usage analyzer inspired by `ncdu`, built with TypeScript and Ink.
+SMDU is a modern, terminal-based disk usage analyser inspired by `ncdu`, built with TypeScript and Ink.
 
 ## Features
 
@@ -8,6 +8,8 @@ SMDU is a modern, terminal-based disk usage analyzer inspired by `ncdu`, built w
 -   **Interactive UI:** Navigate through your file system with ease.
 -   **Visual Feedback:** Size bars and percentages help identify large files quickly.
 -   **Theming:** Includes built-in themes (Default, Dracula).
+-   **Fullscreen TUI:** Uses the alternate screen buffer by default to keep scrollback intact after exit.
+-   **Adaptive Layout:** Columns adjust to terminal size and keep totals, sort, and units visible.
 -   **Cross-Platform:** Works on Linux, macOS, and Windows (best on POSIX).
 
 ## Installation
@@ -45,6 +47,7 @@ smdu /var/log
 
 -   `--theme <name>`: Choose a theme (default, dracula). This overrides the configuration file.
 -   `--units <units>`: Display units (iec, si). This overrides the configuration file.
+-   `--no-fullscreen`: Disable the alternate screen buffer.
 -   `--help`: Show help.
 -   `--version`: Show version.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,7 +1,7 @@
 # SMDU (See My Disk Usage) Specification
 
 ## Overview
-SMDU is a TUI disk usage analyzer inspired by `ncdu`. It is built with TypeScript, React, and Ink.
+SMDU is a TUI disk usage analyser inspired by `ncdu`. It is built with TypeScript, React, and Ink.
 
 ## Features
 - **Directory Scanning:** Recursively scans directories to calculate file sizes.
@@ -10,7 +10,10 @@ SMDU is a TUI disk usage analyzer inspired by `ncdu`. It is built with TypeScrip
 - **Sorting:** Sort files by name or size.
 - **Deletion:** Delete files or directories with a confirmation modal.
 - **Theming:** Support for multiple colour themes (Default, Dracula).
-- **Settings:** Persistent configuration for themes.
+- **Settings:** Persistent configuration for themes and units.
+- **Fullscreen:** Uses the alternate screen buffer by default; `--no-fullscreen` opts out.
+- **Adaptive Layout:** Column widths and the graph adjust to terminal size.
+- **Feedback:** Footer shows totals, sort, and units; a spinner displays during scanning.
 
 ## Architecture
 
@@ -52,7 +55,7 @@ SMDU is a TUI disk usage analyzer inspired by `ncdu`. It is built with TypeScrip
     -   `Settings`: Screen for selecting themes.
 
 4.  **Configuration (`src/config.ts`)**
-    -   Uses `conf` to store settings (theme).
+    -   Uses `conf` to store settings (theme, units).
 
 5.  **Theming (`src/themes.ts`)**
     -   Interface `Theme` with properties for `text`, `highlight`, `bar`, `background`.
@@ -63,11 +66,11 @@ SMDU is a TUI disk usage analyzer inspired by `ncdu`. It is built with TypeScrip
 -   **List:**
     -   `[--#-------]  80%  src/` (Selected item highlighted)
     -   `[----------]  20%  package.json`
--   **Footer:** `Delete: d | Settings: S | Quit: q | Navigation: Arrows`
+-   **Footer:** `Total: 101.21 MiB (15 items) | Sort: Size (desc) | Units: IEC | Delete: d | Settings: S | Quit: q | Navigation: Arrows`
 
 ## Theming
 -   **Default:** Standard terminal colours (Green bars, White text).
--   **Dracula:** Purple/Pink accents, dark background optimized.
+-   **Dracula:** Purple/Pink accents, dark background optimised.
 
 ## Testing Strategy
 -   Unit tests for `scanner` logic (mocking `fs`).


### PR DESCRIPTION
- Document default fullscreen (alternate screen buffer) and the `--no-fullscreen` option
- Describe adaptive layout behaviour, footer status details, and the scanning spinner
- Add guidance in AGENTS.md to keep README and SPEC in sync with user-facing changes