### PR TITLE
Add focus timer pane and controls

### DIFF
--- a/IDEAS.md
+++ b/IDEAS.md
@@ -174,7 +174,7 @@ SMDU is growing beyond the Unix "do one thing well" principle - and that's okay!
 
 ---
 
-### 9. Timer Mode
+### 9. Timer Mode ✅
 **Problem:** Open-ended cleaning sessions can be overwhelming  
 **Solution:** Set a focus timer with visual countdown  
 **Impact:** High for ADHD users  

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ SMDU is a modern, terminal-based disk usage analyser inspired by `ncdu`, built w
 -   **Hidden Files Toggle:** Show or hide dotfiles with `.`.
 -   **Planned:** List view (name-only entries).
 -   **View Modes:** Flat (ncdu-style, default) and Tree.
--   **Planned:** List view (name-only entries).
 -   **Help Modal:** Press `?` to view keybindings.
 -   **Information Panel:** Press `i` to view details for the selected item.
+-   **Focus Timer:** Press `T` to start a 5/10/15/30 minute focus timer with session stats and a completion bell.
 -   **Cross-Platform:** Works on Linux, macOS, and Windows (best on POSIX).
 
 ## Installation
@@ -88,6 +88,9 @@ Settings available:
 -   **L**: Toggle the file type legend.
 -   **H**: Toggle heatmap size bars.
 -   **p**: Toggle the status panel.
+-   **T**: Start a focus timer (cycles 5/10/15/30 minutes).
+-   **t**: Toggle focus timer display (shows the timer pane even when idle).
+-   **c**: Cancel the focus timer.
 -   **?**: Toggle help.
 -   **q / Esc**: Quit (during scan, cancels).
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -12,6 +12,7 @@ SMDU is a TUI disk usage analyser inspired by `ncdu`. It is built with TypeScrip
 - **Help Modal:** Display keybindings with `?`.
 - **Information Panel:** Display details for the selected item with `i`.
 - **Deletion:** Delete files or directories with a confirmation modal.
+- **Focus Timer:** Start a 5/10/15/30 minute timer with session stats and completion alert.
 - **Theming:** Support for multiple colour themes (Default, Dracula).
 - **File Type Colours:** Colour-coded file entries by category with an optional legend toggle.
 - **Heatmap Bars:** Green-to-red heatmap colours for size bars with `H` (default on).
@@ -78,6 +79,7 @@ SMDU is a TUI disk usage analyser inspired by `ncdu`. It is built with TypeScrip
     -   `ConfirmDelete`: Modal for deletion.
     -   `InfoModal`: Modal for file and directory details.
     -   `Settings`: Screen for selecting themes.
+    -   `TimerStatus`: Shows focus timer countdown and session stats.
 
 4.  **Configuration (`src/config.ts`)**
     -   Uses `conf` to store settings (theme, units, file type colours, heatmap, hidden files).
@@ -89,8 +91,10 @@ SMDU is a TUI disk usage analyser inspired by `ncdu`. It is built with TypeScrip
 ## UI/UX
 -   **Header:** `/home/user/projects/smdu` (Yellow/Bold).
 -   **Status Panel:** Right-side panel shows sort/view/hidden/heatmap/legend state and key hints.
--   **Footer:** Shows a partial scan indicator while scanning.
+-   **Footer:** Shows totals with a partial scan indicator while scanning.
 -   **Scan Status:** Displays live progress above the footer while scanning.
+-   **Timer:** `T` starts a focus timer and shows a countdown or completion message above the footer, with a bell on completion.
+-   **Timer Controls:** `t` toggles the timer display (even when idle), `c` cancels the timer.
 -   **Help:** `?` opens the keybinding modal.
 -   **Info Panel:** `i` opens the information panel for the selected item.
 -   **Scan:** `q` cancels the scan and exits.
@@ -103,7 +107,7 @@ SMDU is a TUI disk usage analyser inspired by `ncdu`. It is built with TypeScrip
 -   **Heatmap:** `H` toggles heatmap colours for size bars.
 -   **Status Panel:** `p` toggles the right-side status panel.
 -   **Hidden Files:** `.` toggles dotfiles in the list.
--   **Footer:** `Total: 101.21 MiB (15 items) | Sort: Size (desc) | Units: IEC | Delete: d | Settings: S | Quit: q | Navigation: Arrows`
+-   **Footer:** `Total: 101.21 MiB (15 items) | Scan: Partial` + `Help: ? | Info: i | Panel: p | Timer: T`
 
 ## Theming
 -   **Default:** Standard terminal colours (Green bars, White text).

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { HelpModal } from './components/HelpModal.js';
 import { InfoModal } from './components/InfoModal.js';
 import { ScanStatus } from './components/ScanStatus.js';
 import { StatusPanel } from './components/StatusPanel.js';
+import { TimerStatus } from './components/TimerStatus.js';
 import { useFileSystem } from './state.js';
 import { getTheme } from './themes.js';
 import {
@@ -38,6 +39,8 @@ enum ViewState {
   FileList = 'filelist',
   Settings = 'settings',
 }
+
+const TIMER_MINUTES = [5, 10, 15, 30];
 
 export const App: React.FC<AppProps> = ({ startPath, themeName: initialThemeName, units: initialUnits }) => {
   const { exit } = useApp();
@@ -71,6 +74,7 @@ export const App: React.FC<AppProps> = ({ startPath, themeName: initialThemeName
   const [showInfo, setShowInfo] = useState(false);
   const [showLegend, setShowLegend] = useState(false);
   const [showStatusPanel, setShowStatusPanel] = useState(false);
+  const [showTimerStatus, setShowTimerStatus] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [spinnerIndex, setSpinnerIndex] = useState(0);
   const spinnerFrames = ['|', '/', '-', '\\'];
@@ -86,6 +90,19 @@ export const App: React.FC<AppProps> = ({ startPath, themeName: initialThemeName
   const rootNodeRef = useRef<FileNode | null>(null);
   const pendingRootRef = useRef<FileNode | null>(null);
   const partialUpdateTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const timerAlertedRef = useRef(false);
+
+  const [timerIndex, setTimerIndex] = useState(-1);
+  const [timerState, setTimerState] = useState({
+    status: 'idle' as 'idle' | 'running' | 'completed',
+    durationSeconds: 0,
+    remainingSeconds: 0,
+    endsAt: 0,
+  });
+  const [timerStats, setTimerStats] = useState({
+    deletedItems: 0,
+    freedBytes: 0,
+  });
 
   const {
     currentNode,
@@ -111,6 +128,22 @@ export const App: React.FC<AppProps> = ({ startPath, themeName: initialThemeName
   const updateRootNode = useCallback((root: FileNode) => {
     rootNodeRef.current = root;
     setRootNode({ ...root });
+  }, []);
+
+  const startTimer = useCallback((durationMinutes: number) => {
+    const durationSeconds = durationMinutes * 60;
+    setTimerState({
+      status: 'running',
+      durationSeconds,
+      remainingSeconds: durationSeconds,
+      endsAt: Date.now() + durationSeconds * 1000,
+    });
+    setTimerStats({
+      deletedItems: 0,
+      freedBytes: 0,
+    });
+    timerAlertedRef.current = false;
+    setShowTimerStatus(true);
   }, []);
 
   const handleScanProgress = useCallback((progress: ScanProgress) => {
@@ -202,6 +235,38 @@ export const App: React.FC<AppProps> = ({ startPath, themeName: initialThemeName
     return () => clearInterval(timer);
   }, [isScanning]);
 
+  useEffect(() => {
+    if (timerState.status !== 'running') return;
+    const tick = () => {
+      const remainingSeconds = Math.max(0, Math.ceil((timerState.endsAt - Date.now()) / 1000));
+      setTimerState((prev) => {
+        if (prev.status !== 'running') return prev;
+        if (remainingSeconds <= 0) {
+          return {
+            ...prev,
+            status: 'completed',
+            remainingSeconds: 0,
+          };
+        }
+        return {
+          ...prev,
+          remainingSeconds,
+        };
+      });
+    };
+    tick();
+    const timer = setInterval(tick, 1000);
+    return () => clearInterval(timer);
+  }, [timerState.endsAt, timerState.status]);
+
+  useEffect(() => {
+    if (timerState.status !== 'completed' || timerAlertedRef.current) return;
+    if (process.stdout.isTTY) {
+      process.stdout.write('\u0007');
+    }
+    timerAlertedRef.current = true;
+  }, [timerState.status]);
+
 
   useEffect(() => {
     const updateRows = () => {
@@ -257,7 +322,15 @@ export const App: React.FC<AppProps> = ({ startPath, themeName: initialThemeName
 
     if (showConfirmDelete) {
       if (checkInput(input, key, ACTIONS.CONFIRM)) {
-        deleteSelected();
+        void deleteSelected().then((deletedNode) => {
+          if (!deletedNode) return;
+          if (timerState.status === 'running') {
+            setTimerStats((prev) => ({
+              deletedItems: prev.deletedItems + 1,
+              freedBytes: prev.freedBytes + deletedNode.size,
+            }));
+          }
+        });
         setShowConfirmDelete(false);
       } else {
         setShowConfirmDelete(false);
@@ -291,8 +364,40 @@ export const App: React.FC<AppProps> = ({ startPath, themeName: initialThemeName
       return;
     }
 
+    if (checkInput(input, key, ACTIONS.TIMER_TOGGLE)) {
+      setShowTimerStatus((prev) => !prev);
+      return;
+    }
+
+    if (checkInput(input, key, ACTIONS.TIMER_CANCEL)) {
+      if (timerState.status !== 'idle') {
+        setTimerState({
+          status: 'idle',
+          durationSeconds: 0,
+          remainingSeconds: 0,
+          endsAt: 0,
+        });
+        setTimerIndex(-1);
+        setTimerStats({
+          deletedItems: 0,
+          freedBytes: 0,
+        });
+        timerAlertedRef.current = false;
+      }
+      return;
+    }
+
     if (checkInput(input, key, ACTIONS.SETTINGS)) {
       setView(ViewState.Settings);
+      return;
+    }
+
+    if (checkInput(input, key, ACTIONS.TIMER)) {
+      setTimerIndex((prev) => {
+        const nextIndex = (prev + 1) % TIMER_MINUTES.length;
+        startTimer(TIMER_MINUTES[nextIndex]);
+        return nextIndex;
+      });
       return;
     }
 
@@ -447,18 +552,31 @@ export const App: React.FC<AppProps> = ({ startPath, themeName: initialThemeName
       spinnerFrame={spinnerFrames[spinnerIndex]}
     />
   ) : null;
+  const timerIndicator = showTimerStatus ? (
+    <TimerStatus
+      theme={theme}
+      status={timerState.status}
+      remainingSeconds={timerState.remainingSeconds}
+      durationSeconds={timerState.durationSeconds}
+      deletedItems={timerStats.deletedItems}
+      freedBytes={timerStats.freedBytes}
+      formatSize={formatSize}
+    />
+  ) : null;
+  const statusIndicator = timerIndicator ?? scanIndicator;
+  const STATUS_INDICATOR_ROWS = 4;
+  const statusIndicatorRows = statusIndicator ? STATUS_INDICATOR_ROWS : 0;
 
   const maxSize = files.reduce((max, f) => Math.max(max, f.size), 0);
   const headerRows = 3;
   const footerRows = 3;
-  const scanRows = isScanning ? 4 : 0;
   const panelWidth = showStatusPanel
     ? Math.max(26, Math.min(38, Math.floor(totalColumns * 0.32)))
     : 0;
   const listWidth = showStatusPanel
     ? Math.max(20, totalColumns - panelWidth)
     : totalColumns;
-  const panelHeight = Math.max(3, totalRows - headerRows - footerRows - scanRows);
+  const panelHeight = Math.max(3, totalRows - headerRows - footerRows - statusIndicatorRows);
   return (
     <Box flexDirection="column" height={totalRows} width="100%">
       <Header
@@ -470,19 +588,19 @@ export const App: React.FC<AppProps> = ({ startPath, themeName: initialThemeName
         <Box flexDirection="row" width="100%">
           <Box width={showStatusPanel ? listWidth : '100%'}>
             <FileList
-                files={files}
-                selectedIndex={selectionIndex}
-                maxSize={maxSize}
-                theme={theme}
-                units={currentUnits}
-                viewMode={viewMode}
-                rootPath={currentNode.path}
-                scanRootPath={rootNode?.path ?? currentNode.path}
-                fileTypeColoursEnabled={fileTypeColoursEnabled}
-                showLegend={showLegend}
-                heatmapEnabled={heatmapEnabled}
-                availableColumns={listWidth}
-                extraBottomRows={scanRows}
+              files={files}
+              selectedIndex={selectionIndex}
+              maxSize={maxSize}
+              theme={theme}
+              units={currentUnits}
+              viewMode={viewMode}
+              rootPath={currentNode.path}
+              scanRootPath={rootNode?.path ?? currentNode.path}
+              fileTypeColoursEnabled={fileTypeColoursEnabled}
+              showLegend={showLegend}
+              heatmapEnabled={heatmapEnabled}
+              availableColumns={showStatusPanel ? listWidth : undefined}
+              extraBottomRows={statusIndicatorRows}
             />
           </Box>
           {showStatusPanel ? (
@@ -505,7 +623,7 @@ export const App: React.FC<AppProps> = ({ startPath, themeName: initialThemeName
         </Box>
       </Box>
 
-      {scanIndicator}
+      {statusIndicator}
 
       <Footer
         totalSize={currentNode.size}

--- a/src/components/FileList.tsx
+++ b/src/components/FileList.tsx
@@ -94,7 +94,7 @@ export const FileList: React.FC<FileListProps> = ({
 }) => {
   const { stdout } = useStdout();
   const [totalRows, setTotalRows] = useState(() => stdout?.rows ?? process.stdout.rows ?? 24);
-  const [totalColumns, setTotalColumns] = useState(() => availableColumns ?? stdout?.columns ?? process.stdout.columns ?? 80);
+  const totalColumns = availableColumns ?? stdout?.columns ?? process.stdout.columns ?? 80;
   const showLegendRow = showLegend && fileTypeColoursEnabled;
   const listHeaderRows = showLegendRow ? 4 : 3;
   const reservedRows = APP_HEADER_ROWS + listHeaderRows + APP_FOOTER_ROWS + extraBottomRows;
@@ -102,7 +102,6 @@ export const FileList: React.FC<FileListProps> = ({
   useEffect(() => {
     const updateRows = () => {
       setTotalRows(stdout?.rows ?? process.stdout.rows ?? 24);
-      setTotalColumns(availableColumns ?? stdout?.columns ?? process.stdout.columns ?? 80);
     };
 
     updateRows();
@@ -115,13 +114,7 @@ export const FileList: React.FC<FileListProps> = ({
       clearTimeout(immediateTimer);
       clearTimeout(settleTimer);
     };
-  }, [stdout, availableColumns]);
-
-  useEffect(() => {
-    if (availableColumns !== undefined) {
-      setTotalColumns(availableColumns);
-    }
-  }, [availableColumns]);
+  }, [stdout]);
 
   const windowSize = Math.max(1, totalRows - reservedRows);
   const columnLayout = useMemo(() => {

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -25,7 +25,7 @@ export const Footer: React.FC<FooterProps> = ({
   const sizeLabel = filesize(totalSize, units === 'si' ? { base: 10, standard: 'si' } : { base: 2, standard: 'iec' });
   const scanLabel = isScanning ? ' | Scan: Partial' : '';
   const leftText = `Total: ${sizeLabel} (${itemCount} items)${scanLabel}`;
-  const rightText = 'Help: ? | Info: i | Panel: p';
+  const rightText = 'Help: ? | Info: i | Panel: p | Timer: T';
 
   return (
     <Box

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -4,11 +4,12 @@ import { Theme } from '../themes.js';
 interface HeaderProps {
   path: string;
   theme: Theme;
+  width?: number;
 }
 
-export const Header: React.FC<HeaderProps> = ({ path, theme }) => {
+export const Header: React.FC<HeaderProps> = ({ path, theme, width }) => {
   const { stdout } = useStdout();
-  const totalColumns = stdout?.columns ?? process.stdout.columns ?? 80;
+  const totalColumns = width ?? stdout?.columns ?? process.stdout.columns ?? 80;
   const contentWidth = Math.max(20, totalColumns - 2);
 
   return (
@@ -16,7 +17,7 @@ export const Header: React.FC<HeaderProps> = ({ path, theme }) => {
       borderStyle="single"
       borderColor={theme.colours.header}
       paddingX={1}
-      width="100%"
+      width={width ?? '100%'}
     >
       <Box width={contentWidth}>
         <Text color={theme.colours.header} bold wrap="truncate-end">

--- a/src/components/ScanStatus.tsx
+++ b/src/components/ScanStatus.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { Box, Text } from 'ink';
+import { Text } from 'ink';
 import { Theme } from '../themes.js';
+import { StatusBanner } from './StatusBanner.js';
 
 interface ScanStatusProps {
   theme: Theme;
@@ -15,19 +16,12 @@ export const ScanStatus: React.FC<ScanStatusProps> = ({
   currentPath,
   spinnerFrame,
 }) => (
-  <Box
-    paddingX={1}
-    paddingY={0}
-    borderStyle="round"
-    borderColor={theme.colours.footer}
-    flexDirection="column"
-    width="100%"
-  >
-    <Text color={theme.colours.text}>
+  <StatusBanner theme={theme}>
+    <Text color={theme.colours.footer}>
       {summary} {spinnerFrame}
     </Text>
-    <Text color={theme.colours.text} wrap="truncate-end">
+    <Text color={theme.colours.footer} wrap="truncate-end">
       Current: {currentPath}
     </Text>
-  </Box>
+  </StatusBanner>
 );

--- a/src/components/StatusBanner.tsx
+++ b/src/components/StatusBanner.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Box } from 'ink';
+import { Theme } from '../themes.js';
+
+interface StatusBannerProps {
+  theme: Theme;
+  children: React.ReactNode;
+}
+
+export const StatusBanner: React.FC<StatusBannerProps> = ({ theme, children }) => (
+  <Box
+    paddingX={1}
+    paddingY={0}
+    borderStyle="round"
+    borderColor={theme.colours.footer}
+    flexDirection="column"
+    width="100%"
+  >
+    {children}
+  </Box>
+);

--- a/src/components/TimerStatus.tsx
+++ b/src/components/TimerStatus.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { Text } from 'ink';
+import { Theme } from '../themes.js';
+import { StatusBanner } from './StatusBanner.js';
+
+type TimerStatusState = 'idle' | 'running' | 'completed';
+
+interface TimerStatusProps {
+  theme: Theme;
+  status: TimerStatusState;
+  remainingSeconds: number;
+  durationSeconds: number;
+  deletedItems: number;
+  freedBytes: number;
+  formatSize: (bytes: number) => string;
+}
+
+const formatClock = (seconds: number) => {
+  const minutes = Math.floor(seconds / 60);
+  const secs = Math.max(0, seconds % 60);
+  return `${String(minutes).padStart(2, '0')}:${String(secs).padStart(2, '0')}`;
+};
+
+export const TimerStatus: React.FC<TimerStatusProps> = ({
+  theme,
+  status,
+  remainingSeconds,
+  durationSeconds,
+  deletedItems,
+  freedBytes,
+  formatSize,
+}) => {
+  const timerLine = status === 'completed'
+    ? 'Time is up! Great work staying focussed.'
+    : status === 'running'
+      ? `Timer: ${formatClock(remainingSeconds)} remaining of ${formatClock(durationSeconds)}`
+      : 'Timer: Inactive. Press T to start.';
+  const statsLine = status === 'idle'
+    ? 'Session: No activity yet.'
+    : `Session: Freed ${formatSize(freedBytes)} across ${deletedItems} item${deletedItems === 1 ? '' : 's'}.`;
+
+  return (
+    <StatusBanner theme={theme}>
+      <Text color={theme.colours.footer}>{timerLine}</Text>
+      <Text color={theme.colours.footer}>{statsLine}</Text>
+    </StatusBanner>
+  );
+};

--- a/src/keys.ts
+++ b/src/keys.ts
@@ -29,6 +29,9 @@ export const ACTIONS: Record<string, ActionDefinition> = {
   SORT_SIZE: { input: ['s'] },
   VIEW_MODE: { input: ['v'] },
   TOGGLE_HIDDEN: { input: ['.'] },
+  TIMER: { input: ['T'] },
+  TIMER_TOGGLE: { input: ['t'] },
+  TIMER_CANCEL: { input: ['c'] },
   HELP: { input: ['?'] },
   SELECT: { input: [' '], key: ['return'] }, // For settings selection
 };
@@ -81,6 +84,9 @@ export const HELP_ITEMS: HelpItem[] = [
   { label: 'Sort by size', keys: formatActions(['SORT_SIZE']) },
   { label: 'Toggle view mode', keys: formatActions(['VIEW_MODE']) },
   { label: 'Toggle hidden files', keys: formatActions(['TOGGLE_HIDDEN']) },
+  { label: 'Start focus timer', keys: formatActions(['TIMER']) },
+  { label: 'Toggle focus timer display', keys: formatActions(['TIMER_TOGGLE']) },
+  { label: 'Cancel focus timer', keys: formatActions(['TIMER_CANCEL']) },
   { label: 'Delete item', keys: formatActions(['DELETE']) },
   { label: 'Settings', keys: formatActions(['SETTINGS']) },
   { label: 'Information panel', keys: formatActions(['INFO']) },

--- a/src/state.ts
+++ b/src/state.ts
@@ -161,18 +161,18 @@ export const useFileSystem = (initialNode: FileNode | null, showHiddenFiles = fa
     }
   };
 
-  const deleteSelected = useCallback(async () => {
-      if (!currentNode || !currentNode.children) return;
+  const deleteSelected = useCallback(async (): Promise<FileNode | null> => {
+      if (!currentNode || !currentNode.children) return null;
 
       const fileToDelete = files[selectionIndex];
-      if (!fileToDelete) return;
+      if (!fileToDelete) return null;
 
       try {
         // Actual deletion
         await fs.promises.rm(fileToDelete.path, { recursive: true, force: true });
 
         const parentNode = fileToDelete.parent ?? currentNode;
-        if (!parentNode.children) return;
+        if (!parentNode.children) return null;
 
         // State update - Mutate in place to preserve tree consistency
         const index = parentNode.children.indexOf(fileToDelete);
@@ -188,10 +188,12 @@ export const useFileSystem = (initialNode: FileNode | null, showHiddenFiles = fa
         setCurrentNode({ ...currentNode });
 
         setSelectionIndex((prev) => Math.max(0, Math.min(prev, files.length - 2)));
+        return fileToDelete;
       } catch (err: any) {
         setError(`Failed to delete: ${err.message}`);
       }
 
+      return null;
   }, [currentNode, files, selectionIndex]);
 
   useEffect(() => {


### PR DESCRIPTION
- Introduce a focus timer pane with countdown, completion alert, and session stats
- Add timer controls (`T` start, `t` toggle pane, `c` cancel) and update help/keybindings
- Align scan/timer status banner styling and fix list width behaviour when toggling the status panel