### PR TITLE
Add header title

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ SMDU is a modern, terminal-based disk usage analyser inspired by `ncdu`, built w
 -   **File Type Colours:** Colour-codes files by category with an optional legend.
 -   **Heatmap Size Bars:** Green-to-red gradient for size bars (toggle with `H`).
 -   **Hidden Files Toggle:** Show or hide dotfiles with `.`.
+-   **Header Title:** Shows `smdu` centred in the header bar.
 -   **Planned:** List view (name-only entries).
 -   **View Modes:** Flat (ncdu-style, default) and Tree.
 -   **Help Modal:** Press `?` to view keybindings.

--- a/SPEC.md
+++ b/SPEC.md
@@ -89,7 +89,7 @@ SMDU is a TUI disk usage analyser inspired by `ncdu`. It is built with TypeScrip
     -   Context provider to supply the theme to components.
 
 ## UI/UX
--   **Header:** `/home/user/projects/smdu` (Yellow/Bold).
+-   **Header:** `/home/user/projects/smdu` (Yellow/Bold) with `smdu` centred in the border title.
 -   **Status Panel:** Right-side panel shows sort/view/hidden/heatmap/legend state and key hints.
 -   **Footer:** Shows totals with a partial scan indicator while scanning.
 -   **Scan Status:** Displays live progress above the footer while scanning.

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -11,6 +11,8 @@ export const Header: React.FC<HeaderProps> = ({ path, theme, width }) => {
   const { stdout } = useStdout();
   const totalColumns = width ?? stdout?.columns ?? process.stdout.columns ?? 80;
   const contentWidth = Math.max(20, totalColumns - 2);
+  const title = 'smdu';
+  const titleLabel = ` ${title} `;
 
   return (
     <Box
@@ -19,6 +21,11 @@ export const Header: React.FC<HeaderProps> = ({ path, theme, width }) => {
       paddingX={1}
       width={width ?? '100%'}
     >
+      <Box position="absolute" marginTop={-1} width="100%" justifyContent="center">
+        <Text color={theme.colours.header} bold>
+          {titleLabel}
+        </Text>
+      </Box>
       <Box width={contentWidth}>
         <Text color={theme.colours.header} bold wrap="truncate-end">
           {path}


### PR DESCRIPTION
- Centred a `smdu` title label in the header border while keeping the path display intact.
- Documented the header title in the feature list and UI/UX spec.