### PR TITLE
Align percentage calculation with ncdu (relative to directory total)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -617,6 +617,7 @@ export const App: React.FC<AppProps> = ({ startPath, themeName: initialThemeName
               files={files}
               selectedIndex={selectionIndex}
               maxSize={maxSize}
+              totalSize={currentNode.size}
               theme={theme}
               units={currentUnits}
               viewMode={viewMode}

--- a/src/components/FileList.tsx
+++ b/src/components/FileList.tsx
@@ -11,6 +11,7 @@ interface FileListProps {
   files: FileNode[];
   selectedIndex: number;
   maxSize: number; // Size of the largest file in the list, for bar calculation
+  totalSize: number; // Total size of all files in the directory for percentage calculation
   theme: Theme;
   units: 'iec' | 'si';
   viewMode: ViewMode;
@@ -81,6 +82,7 @@ export const FileList: React.FC<FileListProps> = ({
   files,
   selectedIndex,
   maxSize,
+  totalSize,
   theme,
   units,
   viewMode,
@@ -237,10 +239,16 @@ export const FileList: React.FC<FileListProps> = ({
       {visibleFiles.map((file, index) => {
         const globalIndex = start + index;
         const isSelected = globalIndex === selectedIndex;
-        const percentage = maxSize > 0 ? (file.size / maxSize) * 100 : 0;
-        const barFilled = Math.round((percentage / 100) * columnLayout.barWidth);
+
+        // Percentage is relative to the directory total size
+        const percentage = totalSize > 0 ? (file.size / totalSize) * 100 : 0;
+
+        // Bar is relative to the largest item in the directory
+        const barRatio = maxSize > 0 ? file.size / maxSize : 0;
+        const barFilled = Math.round(barRatio * columnLayout.barWidth);
         const barEmpty = Math.max(0, columnLayout.barWidth - barFilled);
-        const heatmapColour = getHeatmapColour(maxSize > 0 ? file.size / maxSize : 0);
+
+        const heatmapColour = getHeatmapColour(barRatio);
         const barColour = heatmapEnabled ? heatmapColour : theme.colours.bar;
         const barFilledStr = '#'.repeat(barFilled);
         const barEmptyStr = '.'.repeat(barEmpty);

--- a/tests/components/FileList.test.tsx
+++ b/tests/components/FileList.test.tsx
@@ -37,6 +37,7 @@ const mockFiles: FileNode[] = [
     path: '/root/dir1',
     size: 1000,
     isDirectory: true,
+    isHidden: false,
     mtime: new Date(),
   },
   {
@@ -44,6 +45,7 @@ const mockFiles: FileNode[] = [
     path: '/root/file1.txt',
     size: 500,
     isDirectory: false,
+    isHidden: false,
     mtime: new Date(),
   },
 ];
@@ -55,6 +57,7 @@ describe('FileList', () => {
         files={mockFiles}
         selectedIndex={0}
         maxSize={1000}
+        totalSize={1500}
         theme={mockTheme}
         units="iec"
         viewMode="tree"
@@ -69,7 +72,7 @@ describe('FileList', () => {
     const output = lastFrame();
     expect(output).toContain('dir1');
     expect(output).toContain('file1.txt');
-    expect(output).toContain('100.0%'); // dir1
-    expect(output).toContain('50.0%'); // file1
+    expect(output).toContain('66.7%'); // dir1: 1000 / 1500
+    expect(output).toContain('33.3%'); // file1: 500 / 1500
   });
 });


### PR DESCRIPTION
This PR updates the percentage calculation in the file list to match `ncdu`'s behavior.

**Changes:**
- **Percentage Calculation:** Percentages are now calculated relative to the **total size of the current directory**, rather than the largest file in the directory. This provides a true representation of how much space a file consumes within its parent folder.
- **Usage Bars:** The visual usage bars (graphs) remain relative to the **largest file** in the list to maintain helpful visual scaling.
- **Tests:** Updated `FileList` tests to verify that percentages sum correctly relative to the total directory size.

**Files Modified:**
- `src/components/FileList.tsx`
- `src/App.tsx`
- `tests/components/FileList.test.tsx`