### PR TITLE
Add -v alias for version

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ smdu /var/log
 -   `--units <units>`: Display units (iec, si). This overrides the configuration file.
 -   `--no-fullscreen`: Disable the alternate screen buffer.
 -   `--help`: Show help.
--   `--version`: Show version.
+-   `-v, --version`: Show version.
 
 ## Configuration
 

--- a/man/smdu.1
+++ b/man/smdu.1
@@ -21,7 +21,7 @@ Do not use the alternate screen buffer. By default, \fBsmdu\fR switches to the a
 .B \-h, \-\-help
 Display help information.
 .TP
-.B \-V, \-\-version
+.B \-v, \-\-version
 Display version information.
 .SH KEY BINDINGS
 .SS Navigation

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -10,7 +10,7 @@ const program = new Command();
 program
   .name('smdu')
   .description('See My Disk Usage - A clone of ncdu')
-  .version(VERSION)
+  .version(VERSION, '-v, --version')
   .argument('[path]', 'Path to scan', process.cwd())
   .option('-t, --theme <theme>', 'Theme (default, dracula)')
   .option('-u, --units <units>', 'Display units (iec, si)')


### PR DESCRIPTION
## Description
### What
- add `-v` as an alias for `--version` in the CLI
- update `README` and man page to document the new alias

### Why
- make the version flag quicker to type and consistent with common CLI conventions