### PR TITLE
🎨 Palette: Actionable Empty States

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,8 @@
 
 **Learning:** Users often delete the wrong item in TUIs because "selected item" context can be lost when a modal appears.
 **Action:** Always include the item name, type (file/directory), and size in delete confirmation dialogs to provide a final safety check.
+
+## 2024-05-23 - Actionable Empty States
+
+**Learning:** When a user encounters an empty state (like an empty directory), just telling them "it's empty" leaves them stranded, and they might think they have to quit. Providing a clear, actionable next step reduces friction.
+**Action:** Always include a helpful call-to-action in empty states (e.g. "Press Left Arrow or Backspace to go back").

--- a/src/components/FileList.tsx
+++ b/src/components/FileList.tsx
@@ -269,10 +269,15 @@ export const FileList: React.FC<FileListProps> = ({
 			</Box>
 			<Text color={theme.colours.line}>{divider}</Text>
 			{files.length === 0 ? (
-				<Box paddingX={1} paddingTop={1} justifyContent="center">
+				<Box paddingX={1} paddingTop={1} flexDirection="column" alignItems="center">
 					<Text color={theme.colours.muted} italic>
 						This directory is empty.
 					</Text>
+					<Box marginTop={1}>
+						<Text color={theme.colours.muted}>
+							Press <Text bold>Left Arrow</Text> or <Text bold>Backspace</Text> to go back
+						</Text>
+					</Box>
 				</Box>
 			) : null}
 			{visibleFiles.map((file, index) => {


### PR DESCRIPTION
💡 What: Added an actionable keyboard hint to the empty directory state in `FileList.tsx`.
🎯 Why: When a user encounters an empty directory, they might feel stranded. Providing explicit instructions on how to go back reduces friction and improves discoverability.
📸 Before/After: Visual change in the TUI when rendering an empty directory.
♿ Accessibility: Provides explicit instruction instead of just a visual blank state.

---
*PR created automatically by Jules for task [4079472606310860430](https://jules.google.com/task/4079472606310860430) started by @ScottMorris*