### PR TITLE
Prepare macOS release archives for Homebrew distribution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,6 +174,21 @@ jobs:
             --binary dist/smdu \
             --output-prefix "dist/smdu-${{ needs.prepare-release.outputs.tag_name }}-${{ matrix.target }}"
 
+      - name: Build macOS package archives
+        if: startsWith(matrix.target, 'macos-')
+        shell: bash
+        run: |
+          set -euo pipefail
+          ARCH="x64"
+          if [[ "${{ matrix.target }}" == "macos-arm64" ]]; then
+            ARCH="arm64"
+          fi
+          scripts/build-macos-packages.sh \
+            --version "${{ needs.prepare-release.outputs.tag_name }}" \
+            --arch "${ARCH}" \
+            --binary dist/smdu \
+            --output-prefix "dist/smdu-${{ needs.prepare-release.outputs.tag_name }}-${{ matrix.target }}"
+
       - name: Prepare release asset (unix)
         if: runner.os != 'Windows'
         run: |
@@ -217,6 +232,8 @@ jobs:
             dist/*.deb.sha256
             dist/*.rpm
             dist/*.rpm.sha256
+            dist/*.tar.gz
+            dist/*.tar.gz.sha256
           if-no-files-found: error
 
   build-windows-installers:

--- a/README.md
+++ b/README.md
@@ -67,6 +67,20 @@ The packaging script outputs artefacts under `dist/` and installs files to distr
 - binary: `/usr/bin/smdu`
 - man page: `/usr/share/man/man1/smdu.1.gz`
 
+### macOS Homebrew Prep Archives (`.tar.gz`)
+
+Build Homebrew-oriented macOS archives locally:
+
+```bash
+pnpm build:macos:package:x64
+pnpm build:macos:package:arm64
+```
+
+Release automation publishes tarball artefacts named `smdu-<tag>-macos-<arch>.tar.gz`. Each archive includes:
+
+- `smdu` (executable)
+- `smdu.1.gz` (manual page payload for formula install)
+
 ### Windows Installer Builds (`.msi`)
 
 Build a Windows MSI locally:

--- a/SPEC.md
+++ b/SPEC.md
@@ -17,6 +17,7 @@ The following install paths are the canonical defaults for supported platform fa
 Platform-specific exceptions must be documented in `README.md` and linked to the package method that requires them.
 
 Linux release packaging must produce both `.deb` and `.rpm` artefacts and place files in distro-managed paths (`/usr/bin/smdu`, `/usr/share/man/man1/smdu.1.gz`) unless a platform policy requires an override.
+macOS release packaging must produce architecture-specific `.tar.gz` archives that include both the `smdu` binary and `smdu.1.gz` for Homebrew formula installation.
 Windows release packaging must produce MSI installer artefacts for supported architectures and ensure installs add `%LOCALAPPDATA%\\Programs\\smdu` to the per-user `PATH`.
 
 ## Features

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
 		"build:linux:packages": "pnpm build && pnpm build:binary && scripts/build-linux-packages.sh",
 		"build:linux:deb": "pnpm build && pnpm build:binary && scripts/build-linux-packages.sh --format deb",
 		"build:linux:rpm": "pnpm build && pnpm build:binary && scripts/build-linux-packages.sh --format rpm",
+		"build:macos:package:x64": "pnpm build && bun build --compile --minify --sourcemap --bytecode src/cli.tsx --outfile dist/smdu --format esm --target bun-darwin-x64 && scripts/build-macos-packages.sh --arch x64",
+		"build:macos:package:arm64": "pnpm build && bun build --compile --minify --sourcemap --bytecode src/cli.tsx --outfile dist/smdu --format esm --target bun-darwin-arm64 && scripts/build-macos-packages.sh --arch arm64",
 		"build:windows:installer:x64": "pnpm build && bun build --compile --minify --sourcemap --bytecode src/cli.tsx --outfile dist/smdu.exe --format esm --target bun-windows-x64 && pwsh -File scripts/build-windows-installer.ps1 -Arch x64",
 		"build:windows:installer:arm64": "pnpm build && bun build --compile --minify --sourcemap --bytecode src/cli.tsx --outfile dist/smdu.exe --format esm --target bun-windows-arm64 && pwsh -File scripts/build-windows-installer.ps1 -Arch arm64",
 		"watch": "tsc -w",

--- a/scripts/build-macos-packages.sh
+++ b/scripts/build-macos-packages.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+VERSION=""
+ARCH_INPUT=""
+BINARY_PATH=""
+MAN_PAGE_PATH="${REPO_ROOT}/man/smdu.1"
+OUTPUT_PREFIX=""
+
+usage() {
+	cat <<USAGE
+Usage: scripts/build-macos-packages.sh [options]
+
+Options:
+  --version <version>         Package version (default: package.json version)
+  --arch <x64|arm64>          Target architecture (required)
+  --binary <path>             Built binary path (default: dist/smdu)
+  --man-page <path>           Man page source path (default: man/smdu.1)
+  --output-prefix <prefix>    Output file prefix (default: dist/smdu-v<version>-macos-<arch>)
+  -h, --help                  Show this help
+USAGE
+}
+
+resolve_version() {
+	node -p "JSON.parse(require('fs').readFileSync('${REPO_ROOT}/package.json', 'utf8')).version"
+}
+
+normalise_arch() {
+	case "$1" in
+		x64 | amd64 | x86_64)
+			echo "x64"
+			;;
+		arm64 | aarch64)
+			echo "arm64"
+			;;
+		*)
+			echo "Unsupported architecture: $1" >&2
+			exit 1
+			;;
+	esac
+}
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+		--version)
+			VERSION="$2"
+			shift 2
+			;;
+		--arch)
+			ARCH_INPUT="$2"
+			shift 2
+			;;
+		--binary)
+			BINARY_PATH="$2"
+			shift 2
+			;;
+		--man-page)
+			MAN_PAGE_PATH="$2"
+			shift 2
+			;;
+		--output-prefix)
+			OUTPUT_PREFIX="$2"
+			shift 2
+			;;
+		-h | --help)
+			usage
+			exit 0
+			;;
+		*)
+			echo "Unknown option: $1" >&2
+			usage
+			exit 1
+			;;
+	esac
+done
+
+if [[ -z "${VERSION}" ]]; then
+	VERSION="$(resolve_version)"
+fi
+
+if [[ -z "${ARCH_INPUT}" ]]; then
+	echo "--arch is required (x64 or arm64)" >&2
+	exit 1
+fi
+
+ARCH="$(normalise_arch "${ARCH_INPUT}")"
+
+if [[ -z "${BINARY_PATH}" ]]; then
+	BINARY_PATH="${REPO_ROOT}/dist/smdu"
+fi
+
+if [[ -z "${OUTPUT_PREFIX}" ]]; then
+	OUTPUT_PREFIX="${REPO_ROOT}/dist/smdu-v${VERSION}-macos-${ARCH}"
+fi
+
+if [[ ! -f "${BINARY_PATH}" ]]; then
+	echo "Built binary not found at ${BINARY_PATH}" >&2
+	exit 1
+fi
+
+if [[ ! -f "${MAN_PAGE_PATH}" ]]; then
+	echo "Man page source not found at ${MAN_PAGE_PATH}" >&2
+	exit 1
+fi
+
+mkdir -p "$(dirname "${OUTPUT_PREFIX}")"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+PAYLOAD_DIR="${TMP_DIR}/payload"
+mkdir -p "${PAYLOAD_DIR}"
+
+install -m 0755 "${BINARY_PATH}" "${PAYLOAD_DIR}/smdu"
+gzip -c "${MAN_PAGE_PATH}" > "${PAYLOAD_DIR}/smdu.1.gz"
+
+ARCHIVE_OUTPUT="${OUTPUT_PREFIX}.tar.gz"
+tar -C "${PAYLOAD_DIR}" -czf "${ARCHIVE_OUTPUT}" smdu smdu.1.gz
+sha256sum "${ARCHIVE_OUTPUT}" > "${ARCHIVE_OUTPUT}.sha256"
+
+echo "Built ${ARCHIVE_OUTPUT}"


### PR DESCRIPTION
## Summary
- add macOS archive packaging for Homebrew prep (`smdu` + `smdu.1.gz`)
- add local package scripts for x64 and arm64 archive builds
- update release workflow to publish macOS tarballs and checksums
- document macOS Homebrew-prep archive behaviour in README and SPEC

## Validation
- `pnpm build`
- `pnpm test`
- `pnpm format:check`
- `pnpm build:macos:package:x64`
- `pnpm build:macos:package:arm64`
- `tar -tzf dist/smdu-v0.0.1-macos-x64.tar.gz`
- `tar -tzf dist/smdu-v0.0.1-macos-arm64.tar.gz`

## Related
- Partially addresses #48
