### PR TITLE
Show % in the percent column header

### DIFF
--- a/src/components/FileList.tsx
+++ b/src/components/FileList.tsx
@@ -242,7 +242,7 @@ export const FileList: React.FC<FileListProps> = ({
 					</Box>
 					<Box width={1} />
 					<Box width={columnLayout.percentColumns} justifyContent="flex-end">
-						<Text color={theme.colours.muted}>{columnLayout.showGraph ? '' : 'Usage'}</Text>
+						<Text color={theme.colours.muted}>%</Text>
 					</Box>
 					{columnLayout.showGraph ? (
 						<>

--- a/tests/components/FileList.test.tsx
+++ b/tests/components/FileList.test.tsx
@@ -79,6 +79,7 @@ describe('FileList', () => {
 		);
 
 		const output = lastFrame();
+		expect(output).toMatch(/Size\s+%\s+Usage/);
 		expect(output).toContain('dir1');
 		expect(output).toContain('file1.txt');
 		expect(output).toContain('66.7%'); // dir1: 1000 / 1500


### PR DESCRIPTION
## Summary
- add the missing `%` symbol to the percent column header in the file list
- add a regression test to verify the header includes `Size`, `%`, and `Usage`

## Validation
- `pnpm test`
- `pnpm build`

Closes #73