### PR TITLE
Clarify AGENTS merge strategy for PRs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,8 @@
 
 **Requirement:** Do not push changes (especially force pushes) to the repository unless explicitly requested by the user.
 
+- Do not squash-merge PRs unless the user explicitly requests squash for that PR.
+
 ## Testing
 
 - **Mandatory Testing:** Make sure the unit tests are run after changes to the code.


### PR DESCRIPTION
## Summary
- add a Git workflow rule in `AGENTS.md` to avoid squash merges unless explicitly requested

## Why
- keep commit history shape predictable when merging PRs
- avoid accidental strategy mismatches during rapid follow-up changes
