### PR TITLE
Support scanning multiple paths

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,7 +39,7 @@ import fs from 'fs';
 import { filesize } from 'filesize';
 
 interface AppProps {
-	startPath: string;
+	startPaths: string[];
 	themeName?: string; // Flag overrides config
 	units?: string; // Flag overrides config
 	onSuspend?: () => void;
@@ -63,11 +63,15 @@ interface SelectedFileMetadata {
 const TIMER_MINUTES = [5, 10, 15, 30];
 
 export const App: React.FC<AppProps> = ({
-	startPath,
+	startPaths,
 	themeName: initialThemeName,
 	units: initialUnits,
 	onSuspend,
 }) => {
+	const displayLabel =
+		startPaths.length === 1
+			? startPaths[0]
+			: startPaths.map((p) => path.basename(path.resolve(p))).join(', ');
 	const { exit } = useApp();
 	const { stdout } = useStdout();
 	const [totalRows, setTotalRows] = useState(() => stdout?.rows ?? process.stdout.rows ?? 24);
@@ -109,7 +113,7 @@ export const App: React.FC<AppProps> = ({
 	const [spinnerIndex, setSpinnerIndex] = useState(0);
 	const spinnerFrames = ['|', '/', '-', '\\'];
 	const [scanStatus, setScanStatus] = useState<ScanProgress>({
-		currentPath: startPath,
+		currentPath: startPaths[0] ?? '',
 		directories: 0,
 		files: 0,
 		bytes: 0,
@@ -228,40 +232,92 @@ export const App: React.FC<AppProps> = ({
 		[updateRootNode],
 	);
 
+	const createVirtualRoot = useCallback(
+		(children: FileNode[]): FileNode => {
+			const virtualRoot: FileNode = {
+				name: displayLabel,
+				path: '<multi>',
+				size: children.reduce((sum, c) => sum + c.size, 0),
+				fileCount: children.reduce((sum, c) => sum + c.fileCount, 0),
+				isDirectory: true,
+				isHidden: false,
+				mtime: new Date(),
+				children,
+				isVirtualRoot: true,
+			};
+			for (const child of children) {
+				child.parent = virtualRoot;
+			}
+			return virtualRoot;
+		},
+		[displayLabel],
+	);
+
 	const scanRef = useCallback(() => {
 		const runScan = async () => {
 			try {
-				const absolutePath = path.resolve(startPath);
+				const absolutePaths = startPaths.map((p) => path.resolve(p));
 				const controller = new AbortController();
 				scanAbortRef.current = controller;
 				setIsScanning(true);
 				setLoading(true);
 				rootNodeRef.current = null;
-				setRootNode(null); // Release memory of old tree immediately
-				// Allow a small delay for state update and potential GC
+				setRootNode(null);
 				await new Promise((resolve) => setTimeout(resolve, 50));
-				const progressState: ScanProgress = {
-					currentPath: absolutePath,
+
+				const progressPerPath: ScanProgress[] = absolutePaths.map((p) => ({
+					currentPath: p,
 					directories: 0,
 					files: 0,
 					bytes: 0,
 					errors: 0,
+				}));
+				setScanStatus(progressPerPath[0]);
+
+				const mergeProgress = (index: number, progress: ScanProgress) => {
+					progressPerPath[index] = progress;
+					const merged: ScanProgress = {
+						currentPath: progress.currentPath,
+						directories: progressPerPath.reduce((s, p) => s + p.directories, 0),
+						files: progressPerPath.reduce((s, p) => s + p.files, 0),
+						bytes: progressPerPath.reduce((s, p) => s + p.bytes, 0),
+						errors: progressPerPath.reduce((s, p) => s + p.errors, 0),
+					};
+					handleScanProgress(merged);
 				};
-				setScanStatus(progressState);
-				const root = await scanDirectory(
-					absolutePath,
-					undefined,
-					handleScanProgress,
-					progressState,
-					controller.signal,
-					handlePartialUpdate,
+
+				const isMultiPath = absolutePaths.length > 1;
+				const partialRoots: (FileNode | null)[] = absolutePaths.map(() => null);
+
+				const handleMultiPartial = (index: number, root: FileNode) => {
+					partialRoots[index] = root;
+					const available = partialRoots.filter(Boolean) as FileNode[];
+					if (available.length > 0) {
+						handlePartialUpdate(createVirtualRoot(available));
+					}
+				};
+
+				const roots = await Promise.all(
+					absolutePaths.map((absPath, i) =>
+						scanDirectory(
+							absPath,
+							undefined,
+							(progress) => mergeProgress(i, progress),
+							progressPerPath[i],
+							controller.signal,
+							isMultiPath ? (root) => handleMultiPartial(i, root) : handlePartialUpdate,
+						),
+					),
 				);
+
 				if (partialUpdateTimerRef.current) {
 					clearTimeout(partialUpdateTimerRef.current);
 					partialUpdateTimerRef.current = null;
 				}
 				pendingRootRef.current = null;
-				updateRootNode(root);
+
+				const finalRoot = roots.length === 1 ? roots[0] : createVirtualRoot(roots);
+				updateRootNode(finalRoot);
 				setLoading(false);
 				setIsScanning(false);
 			} catch (err) {
@@ -278,7 +334,14 @@ export const App: React.FC<AppProps> = ({
 			}
 		};
 		runScan();
-	}, [startPath, exit, handleScanProgress, handlePartialUpdate, updateRootNode]);
+	}, [
+		startPaths,
+		exit,
+		handleScanProgress,
+		handlePartialUpdate,
+		updateRootNode,
+		createVirtualRoot,
+	]);
 
 	useEffect(() => {
 		scanRef();
@@ -612,7 +675,7 @@ export const App: React.FC<AppProps> = ({
 		}
 
 		if (checkInput(input, key, ACTIONS.DELETE)) {
-			if (selectedFile) {
+			if (selectedFile && !selectedFile.isVirtualRoot) {
 				setShowConfirmDelete(true);
 			}
 		}
@@ -739,12 +802,12 @@ export const App: React.FC<AppProps> = ({
 
 		return (
 			<Box height={totalRows} width="100%" flexDirection="column">
-				<Header path={startPath} theme={theme} viewMode={viewMode} />
+				<Header path={displayLabel} theme={theme} viewMode={viewMode} />
 				<Box flexGrow={1} flexDirection="column">
 					<Text color={theme.colours.line}>{divider}</Text>
 					<Box flexDirection="column" paddingX={1} paddingY={1}>
 						<Text color={theme.colours.text}>
-							Scanning {startPath}... {spinnerFrames[spinnerIndex]}
+							Scanning {displayLabel}... {spinnerFrames[spinnerIndex]}
 						</Text>
 						<Text color={theme.colours.muted} wrap="truncate-end">
 							Current: {scanStatus.currentPath}
@@ -772,11 +835,13 @@ export const App: React.FC<AppProps> = ({
 		);
 	}
 
+	const headerPath = currentNode.isVirtualRoot ? displayLabel : currentNode.path;
+
 	if (showConfirmDelete) {
 		const selectedFile = selectedNode;
 		return (
 			<Box flexDirection="column" height={totalRows} width="100%">
-				<Header path={currentNode.path} theme={theme} viewMode={viewMode} />
+				<Header path={headerPath} theme={theme} viewMode={viewMode} />
 				<Box flexGrow={1} justifyContent="center" alignItems="center">
 					<ConfirmDelete
 						fileName={selectedFile?.name || 'item'}
@@ -839,7 +904,7 @@ export const App: React.FC<AppProps> = ({
 	const effectiveSelectedFile = selectedFile ?? undefined;
 	return (
 		<Box flexDirection="column" height={totalRows} width="100%">
-			<Header path={currentNode.path} theme={theme} viewMode={viewMode} />
+			<Header path={headerPath} theme={theme} viewMode={viewMode} />
 
 			<Box flexGrow={1} overflowY="hidden">
 				<Box flexDirection="row" width="100%">

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -21,19 +21,7 @@ program
 	.option('-u, --units <units>', 'Display units (iec, si)')
 	.option('--no-fullscreen', 'Do not use alternate screen buffer')
 	.action((paths: string[], options) => {
-		const pathStr = paths.length > 0 ? paths[0] : process.cwd();
-
-		if (paths.length > 1) {
-			console.error(
-				'Error: smdu only supports scanning one path at a time.\n' +
-					`Received ${paths.length} paths: ${paths.join(', ')}\n\n` +
-					'If you used a glob (e.g. smdu cat*), the shell expanded it into multiple arguments.\n' +
-					'Quote the path to pass it literally: smdu "cat*"\n\n' +
-					'Multi-path scanning is tracked in https://github.com/liminal-hq/smdu/issues/95',
-			);
-			process.exitCode = 1;
-			return;
-		}
+		const startPaths = paths.length > 0 ? paths : [process.cwd()];
 
 		const useFullscreen = options.fullscreen !== false;
 		const hasTty = process.stdout.isTTY;
@@ -61,7 +49,7 @@ program
 
 		const instance = render(
 			<App
-				startPath={pathStr}
+				startPaths={startPaths}
 				themeName={options.theme}
 				units={options.units}
 				onSuspend={handleSuspend}

--- a/src/components/FileList.tsx
+++ b/src/components/FileList.tsx
@@ -319,8 +319,7 @@ export const FileList: React.FC<FileListProps> = ({
 				const barFilledStr = '#'.repeat(barFilled);
 				const barEmptyStr = '.'.repeat(barEmpty);
 
-				const effectiveScanRoot =
-					scanRootPath === '<multi>' ? rootPath : scanRootPath;
+				const effectiveScanRoot = scanRootPath === '<multi>' ? rootPath : scanRootPath;
 				const basePath = viewMode === 'flat' ? effectiveScanRoot : rootPath;
 				const relativePath =
 					basePath === '<multi>' ? file.name : path.relative(basePath, file.path) || file.name;

--- a/src/components/FileList.tsx
+++ b/src/components/FileList.tsx
@@ -319,9 +319,11 @@ export const FileList: React.FC<FileListProps> = ({
 				const barFilledStr = '#'.repeat(barFilled);
 				const barEmptyStr = '.'.repeat(barEmpty);
 
-				const basePath = viewMode === 'flat' ? scanRootPath : rootPath;
+				const effectiveScanRoot =
+					scanRootPath === '<multi>' ? rootPath : scanRootPath;
+				const basePath = viewMode === 'flat' ? effectiveScanRoot : rootPath;
 				const relativePath =
-					basePath === '<multi>' ? file.path : path.relative(basePath, file.path) || file.name;
+					basePath === '<multi>' ? file.name : path.relative(basePath, file.path) || file.name;
 				const pathSegments = relativePath.split(path.sep).filter(Boolean);
 				const depth = Math.max(0, pathSegments.length - 1);
 				const indent = viewMode === 'tree' ? '  '.repeat(depth) : '';

--- a/src/components/FileList.tsx
+++ b/src/components/FileList.tsx
@@ -320,7 +320,8 @@ export const FileList: React.FC<FileListProps> = ({
 				const barEmptyStr = '.'.repeat(barEmpty);
 
 				const basePath = viewMode === 'flat' ? scanRootPath : rootPath;
-				const relativePath = path.relative(basePath, file.path) || file.name;
+				const relativePath =
+					basePath === '<multi>' ? file.path : path.relative(basePath, file.path) || file.name;
 				const pathSegments = relativePath.split(path.sep).filter(Boolean);
 				const depth = Math.max(0, pathSegments.length - 1);
 				const indent = viewMode === 'tree' ? '  '.repeat(depth) : '';

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -22,6 +22,7 @@ export interface FileNode {
 	mtime: Date;
 	linkTarget?: string;
 	linkError?: string;
+	isVirtualRoot?: boolean;
 }
 
 export interface ScanProgress {

--- a/src/state.ts
+++ b/src/state.ts
@@ -65,6 +65,15 @@ const REVIEW_AGE_FILTER_ORDER: Array<ReviewViewState['filters']['ageBuckets']> =
 export const findNodeByPath = (root: FileNode, targetPath: string): FileNode | null => {
 	if (root.path === targetPath) return root;
 
+	// Virtual root: search each child subtree
+	if (root.isVirtualRoot && root.children) {
+		for (const child of root.children) {
+			const found = findNodeByPath(child, targetPath);
+			if (found) return found;
+		}
+		return null;
+	}
+
 	if (!targetPath.startsWith(root.path)) return null;
 
 	const relative = path.relative(root.path, targetPath);
@@ -577,7 +586,7 @@ export const useFileSystem = (initialNode: FileNode | null, showHiddenFiles = fa
 		if (!currentNode) return null;
 
 		const fileToDelete = selectedNode;
-		if (!fileToDelete) return null;
+		if (!fileToDelete || fileToDelete.isVirtualRoot) return null;
 
 		try {
 			await fs.promises.rm(fileToDelete.path, { recursive: true, force: true });

--- a/tests/App.test.tsx
+++ b/tests/App.test.tsx
@@ -115,7 +115,7 @@ describe('App Integration', () => {
 	});
 
 	test('renders file list after scan', async () => {
-		const { lastFrame } = render(<App startPath="/root" />);
+		const { lastFrame } = render(<App startPaths={['/root']} />);
 
 		let output = lastFrame();
 		// Wait for scan to complete (App uses useEffect)
@@ -134,7 +134,7 @@ describe('App Integration', () => {
 	// test stack in ink-testing-library, which causes flaky false negatives in this suite.
 	// Keep this test as documentation of intended behaviour until upstream input handling stabilizes.
 	test.skip('navigates selection', async () => {
-		const { lastFrame, stdin } = render(<App startPath="/root" />);
+		const { lastFrame, stdin } = render(<App startPaths={['/root']} />);
 
 		// Wait for load
 		await new Promise((r) => setTimeout(r, 100)); // Simplified wait
@@ -156,7 +156,7 @@ describe('App Integration', () => {
 	// in the current ink-testing-library setup and can fail nondeterministically.
 	// We keep the scenario here so expected delete UX remains explicit for future re-enablement.
 	test.skip('deletes a file', async () => {
-		const { lastFrame, stdin } = render(<App startPath="/root" />);
+		const { lastFrame, stdin } = render(<App startPaths={['/root']} />);
 		await new Promise((r) => setTimeout(r, 100));
 
 		// Move to file1.txt (index 1)


### PR DESCRIPTION
## Summary

- **Synthetic virtual root:** When multiple paths are given (e.g. `smdu /var /tmp`), each path is scanned concurrently and results are assembled under a virtual `FileNode` root. The virtual root aggregates size and file count across all scanned subtrees.
- **Progress aggregation:** Each scan tracks its own progress counters, merged into a single live display during scanning.
- **Navigation:** The user navigates between scanned subtrees naturally — `goUp` from a scan root lands on the virtual root, and going up from there does nothing. All existing navigation (flat, tree, review) works unchanged.
- **Delete protection:** The virtual root node cannot be deleted (it has no filesystem path). Real scan roots and their contents can still be deleted normally.
- **Single-path unchanged:** When only one path is provided, no virtual root is created — behaviour is identical to before.

Closes #95

## Test plan

- [x] `smdu /tmp /var` scans both and shows combined view with header `tmp, var`
- [x] Navigate into `/tmp` subtree, go back up to virtual root, navigate into `/var`
- [x] `smdu .` (single path) still works identically to before
- [ ] Press `d` on virtual root — nothing happens (delete blocked)
- [ ] Press `d` on a real file inside a scanned subtree — delete works normally
- [x] All existing tests pass (`pnpm test` — 100 passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)