### PR TITLE
Show symlink target in the status panel

### DIFF
--- a/src/components/StatusPanel.tsx
+++ b/src/components/StatusPanel.tsx
@@ -228,6 +228,15 @@ export const StatusPanel: React.FC<StatusPanelProps> = ({
 		{ label: 'Created', value: formatDate(selectedFileBirthtime), priority: 2 },
 		{ label: 'Modified', value: formatDate(selectedFileMtime), priority: 3 },
 		{ label: 'Perms', value: permissions, priority: 4 },
+		...(selectedFile?.isSymbolicLink
+			? [
+					{
+						label: 'Target',
+						value: selectedFile.linkTarget ?? 'unknown',
+						priority: 5,
+					},
+				]
+			: []),
 	];
 	const propertyRows = [...properties]
 		.sort((a, b) => a.priority - b.priority)


### PR DESCRIPTION
## Summary

- When the selected item is a symbolic link, the status panel (`p`) now shows a **Target** row with the link destination path
- Uses the existing `FileNode.linkTarget` field — no scanner changes needed
- Integrates into the existing properties list with truncation and priority ordering
- Falls back to `unknown` if `linkTarget` is not set

Closes #99

## Test plan

- [x] Select a symlink, press `p` — Target row appears with the link destination
- [ ] Select a broken symlink — Target row still appears, Type shows `link (broken)`
- [x] Select a regular file or directory — no Target row
- [ ] Long target paths are truncated to fit the panel width
- [x] All existing tests pass (`pnpm test` — 100 passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)