### PR TITLE
chore: bump version to 0.0.5

### DIFF
--- a/docs/releases/v0.0.5.md
+++ b/docs/releases/v0.0.5.md
@@ -1,0 +1,23 @@
+# v0.0.5
+
+🔔 What's New
+
+- Added multi-path scanning to scan multiple directories in a single session via synthetic virtual root.
+- Added Ctrl+Z suspend/resume support with proper alternate screen buffer and raw mode handling.
+- Added symlink target display in the status panel for quick link inspection.
+- Added release version preparation script to automate version bumping across release files.
+
+🧭 UX Highlights
+
+- Improved cursor position restore when navigating up the directory tree.
+- Improved path display for virtual root children in both tree and flat view modes.
+
+🐛 Fixes and Reliability
+
+- Fixed shell glob expansion crash when multiple paths were passed as arguments.
+- Fixed broken relative path display under virtual root by falling back to direct file names.
+- Fixed delete guard to prevent deletion attempts on the virtual root node.
+
+🧪 Quality
+
+- Restored formatting compliance for FileList layout updates.

--- a/man/smdu.1
+++ b/man/smdu.1
@@ -1,4 +1,4 @@
-.TH SMDU 1 "March 2026" "0.0.4" "User Commands"
+.TH SMDU 1 "March 2026" "0.0.5" "User Commands"
 .SH NAME
 smdu \- See My Disk Usage - A clone of ncdu
 .SH SYNOPSIS

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "smdu",
-	"version": "0.0.4",
+	"version": "0.0.5",
 	"description": "See My Disk Usage - A clone of ncdu",
 	"main": "dist/cli.js",
 	"type": "module",


### PR DESCRIPTION
## Summary
- Bumps version from `0.0.4` to `0.0.5` in `package.json` and `man/smdu.1`
- Generated using `scripts/prepare-release-version.sh --version 0.0.5`

## Test plan
- [x] `pnpm build && pnpm test`
- [x] Create release notes at `docs/releases/v0.0.5.md`
- [x] Tag `v0.0.5` on main after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)