### PR TITLE
Add a Midnight Commander skin inspired by SMDU

### DIFF
--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -1,0 +1,16 @@
+# Integrations
+
+## Midnight Commander
+
+`docs/integrations/smdu-mc.ini` is a Midnight Commander skin derived from SMDU's default palette.
+It uses ASCII-style panel dividers for the main layout and box-drawing lines for dialogs/modals.
+
+To use it locally:
+
+```bash
+mkdir -p ~/.config/mc/skins
+cp docs/integrations/smdu-mc.ini ~/.config/mc/skins/smdu.ini
+mc -S smdu
+```
+
+If your terminal supports true colour, leave `COLORTERM=truecolor` (or `24bit`) enabled for the closest match.

--- a/docs/integrations/smdu-mc.ini
+++ b/docs/integrations/smdu-mc.ini
@@ -1,0 +1,195 @@
+[skin]
+    description = SMDU-inspired Midnight Commander skin
+    truecolors = true
+
+[Lines]
+    # Alternate panel line set matching the earlier Unicode variant:
+    # horiz = ─
+    # vert = │
+    # lefttop = ┌
+    # righttop = ┐
+    # leftbottom = └
+    # rightbottom = ┘
+    # topmiddle = ┬
+    # bottommiddle = ┴
+    # leftmiddle = ├
+    # rightmiddle = ┤
+    # cross = ┼
+    horiz = -
+    vert = |
+    lefttop = +
+    righttop = +
+    leftbottom = +
+    rightbottom = +
+    topmiddle = +
+    bottommiddle = +
+    leftmiddle = +
+    rightmiddle = +
+    cross = +
+    # Alternate dialog/modal line set matching the earlier Unicode variant:
+    # dhoriz = ─
+    # dvert = │
+    # dlefttop = ┌
+    # drighttop = ┐
+    # dleftbottom = └
+    # drightbottom = ┘
+    # dtopmiddle = ┬
+    # dbottommiddle = ┴
+    # dleftmiddle = ├
+    # drightmiddle = ┤
+    dhoriz = ─
+    dvert = │
+    dlefttop = ┌
+    drighttop = ┐
+    dleftbottom = └
+    drightbottom = ┘
+    dtopmiddle = ┬
+    dbottommiddle = ┴
+    dleftmiddle = ├
+    drightmiddle = ┤
+
+[aliases]
+    Bg = #1b1f24
+    Surface = #2a3340
+    SurfaceFocus = #334154
+    SurfaceEdge = #2e3540
+    Text = #d2d8e1
+    TextStrong = #e6ebf2
+    Muted = #7c8796
+    Header = #9aa4b2
+    Accent = #5aa2ff
+    Success = #2ec66a
+    Warning = #ffd166
+    Media = #ffb454
+    Code = #7dd3fc
+    Script = #86efac
+    Archive = #c4a7e7
+    Danger = #fca5a5
+    DangerBg = #6b2e36
+    InputBg = #222a33
+    ShadowBg = #111418
+
+[core]
+    _default_ = Text;Bg
+    selected = TextStrong;Surface;bold
+    marked = Warning;;bold
+    markselect = Warning;Surface;bold
+    gauge = TextStrong;SurfaceEdge
+    input = TextStrong;InputBg
+    inputunchanged = Muted;InputBg
+    inputmark = Bg;Accent
+    disabled = Muted;Surface
+    reverse = Bg;Accent
+    commandlinemark = Bg;Accent
+    header = Header;;bold
+    shadow = #000000;ShadowBg
+
+[dialog]
+    _default_ = Text;Surface
+    dfocus = TextStrong;SurfaceFocus
+    dhotnormal = Accent
+    dhotfocus = Accent;SurfaceFocus
+    dtitle = TextStrong;;bold
+
+[error]
+    _default_ = TextStrong;DangerBg
+    errdfocus = Bg;Danger
+    errdhotnormal = Warning
+    errdhotfocus = Bg;Danger
+    errdtitle = Warning;;bold
+
+[filehighlight]
+    directory = Accent;;bold
+    executable = Script
+    symlink = Code
+    hardlink =
+    stalelink = Danger
+    device = Archive
+    special = Header
+    core = Danger
+    temp = Muted
+    archive = Archive
+    doc = Warning
+    source = Code
+    media = Media
+    graph = Success
+    database = Header
+
+[menu]
+    _default_ = Text;Surface
+    menusel = TextStrong;SurfaceFocus
+    menuhot = Accent
+    menuhotsel = Accent;SurfaceFocus
+    menuinactive = Muted
+
+[popupmenu]
+    _default_ = Text;Surface
+    menusel = TextStrong;SurfaceFocus
+    menutitle = TextStrong;;bold
+
+[buttonbar]
+    hotkey = Bg;Accent
+    button = TextStrong;Surface
+
+[statusbar]
+    _default_ = TextStrong;SurfaceFocus
+
+[help]
+    _default_ = Text;Surface
+    helpitalic = Muted;;italic
+    helpbold = TextStrong;;bold
+    helplink = Accent;;underline
+    helpslink = Bg;Accent
+    helptitle = TextStrong;;bold
+
+[editor]
+    _default_ = Text;Bg
+    editbold = TextStrong;;bold
+    editmarked = TextStrong;Surface
+    editwhitespace = Muted;Bg
+    editnonprintable = SurfaceEdge;Bg
+    editlinestate = TextStrong;SurfaceFocus
+    bookmark = Bg;Warning
+    bookmarkfound = Bg;Success
+    editrightmargin = SurfaceEdge;Bg
+    editbg = ;Bg
+    editframe = Muted
+    editframeactive = Accent
+    editframedrag = Warning
+
+[viewer]
+    _default_ = Text;Bg
+    viewbold = TextStrong;;bold
+    viewunderline = Accent;;underline
+    viewselected = TextStrong;Surface
+
+[diffviewer]
+    added = Bg;Success
+    changedline = TextStrong;Surface
+    changednew = Bg;Accent
+    changed = TextStrong;Warning
+    removed = TextStrong;DangerBg
+    error = TextStrong;DangerBg
+
+[widget-panel]
+    sort-up-char = ↑
+    sort-down-char = ↓
+    hiddenfiles-show-char = •
+    hiddenfiles-hide-char = ○
+    history-prev-item-char = ←
+    history-next-item-char = →
+    history-show-list-char = ↓
+    filename-scroll-left-char = «
+    filename-scroll-right-char = »
+
+[widget-scrollbar]
+    first-vert-char = ↑
+    last-vert-char = ↓
+    first-horiz-char = «
+    last-horiz-char = »
+    current-char = ■
+    background-char = ▒
+
+[widget-editor]
+    window-state-char = ↕
+    window-close-char = ✕


### PR DESCRIPTION
## Summary
- **Adds an SMDU-inspired Midnight Commander skin** at `docs/integrations/smdu-mc.ini`
- **Documents how to install and launch the skin locally** in `docs/integrations/README.md`
- **Includes commented alternate divider characters** so the skin can switch between ASCII and Unicode line styles

## Validation
- **Checks the README formatting** with `./node_modules/.bin/prettier --check docs/integrations/README.md`
- **Confirms the skin loads locally** in Midnight Commander as `smdu`
