### PR TITLE
Add CLAUDE.md and align AGENTS.md with org house rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,13 +50,23 @@
 - Keep internal triage mechanics in local runbooks, internal labels, and agent workflows only.
 - Use user-facing, outcome-focused language in PR titles and descriptions.
 - Only include internal process details in PR content when explicitly requested by the user.
+- Open pull requests ready for review by default. Only create a draft PR when the user explicitly asks for a draft or when there is a clearly communicated blocker that makes draft status necessary.
+
+**PR Description Format:**
+
+- Prefer a compact markdown structure with `## Summary` and `## Test plan`.
+- Under `## Summary`, use `###` sub-sections when they help group the change cleanly (for example, `### User-facing changes`, `### Packaging`, `### Documentation`).
+- Under each summary section, use flat bullets with bold lead-ins for scanability.
+- Keep the summary focused on outcomes and behaviour changes, not commit history or implementation chronology.
+- Under `## Test plan`, use checklist bullets (`- [x]` / `- [ ]`) with concrete commands, validations, or explicit gaps. If something could not be verified, state that plainly.
 
 ## Pull Request Labels
 
 **Requirement:** Every PR must include labels that describe the change and map to release-note categories.
 
-- Add at least one category label to every PR: `feat`, `feature`, `enhancement`, `fix`, `bug`, `bugfix`, `docs`, `test`, `ci`, `build`, or `chore`.
-- Add additional scope labels where helpful (for example, `release`, `ui`, `scanner`, `cli`).
+- Add at least one primary category label to every PR: `enhancement`, `bug`, `documentation`, `testing`, `ci`, `build`, or `chore`.
+- Prefer the broader Liminal HQ label style over Conventional Commit terms for PR labelling — use `enhancement`/`bug` rather than aliases like `feat`, `feature`, `fix`, `bugfix`, `docs`, or `test`.
+- Add additional scope labels where helpful (for example, `release`, `ui`, `scanner`, `cli`, `infrastructure`, `internal`).
 - Use `skip-changelog` only when a change should be excluded from generated release notes.
 - Keep labels accurate as scope changes during review.
 
@@ -73,6 +83,7 @@
 **Requirement:** Do not push changes (especially force pushes) to the repository unless explicitly requested by the user.
 
 - Do not squash-merge PRs unless the user explicitly requests squash for that PR.
+- **GitHub tooling:** Prefer the `gh` CLI for repository, pull request, label, review, and GitHub Actions work.
 
 ## Release Workflow
 
@@ -93,7 +104,7 @@
   - run `pnpm build`
 - Open a PR with:
   - a human-readable title (no Conventional Commit prefix)
-  - release-note category label(s) (`docs`, `chore`, `fix`, `feat`, etc.) plus `release` scope label when relevant
+  - release-note category label(s) (`documentation`, `chore`, `bug`, `enhancement`, etc.) plus `release` scope label when relevant
 - After merge, publish via an **annotated** Git tag that matches the release workflow trigger (`v*`) in `.github/workflows/release.yml`.
 - When creating the release tag message, include a concise summary derived from `docs/releases/v<version>.md` so the tag history preserves release context.
 - Do not push release branches or tags unless explicitly requested by the user.
@@ -101,7 +112,7 @@
 ## Testing
 
 - **Mandatory Testing:** Make sure the unit tests are run after changes to the code.
-- **Verification:** Always verify code changes by running relevant tests.
+- **Verification:** Always verify code changes by running relevant tests. If verification is incomplete or blocked, say so plainly rather than implying it passed.
 - **Build Check:** Run `pnpm build` to surface any TypeScript errors.
 - **Format Check:** Run `pnpm format:check` before opening or updating a PR, and run `pnpm format` if any files fail formatting.
 
@@ -120,6 +131,7 @@
 - **Requirement:** New source files (and substantially rewritten source files) should include a short header as the first content in the file.
 - **Applies to:** `.ts`, `.tsx`, `.js` source files in `src/` and `tests/` (and scripts where appropriate).
 - **Do not add headers to:** generated files, lockfiles, config files (`.json`, `.yml`, etc.), markdown docs, or man pages.
+- When visiting an existing file that lacks a header, add one as part of the current change.
 
 Preferred header format for TypeScript/JavaScript:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,50 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+SMDU ("See My Disk Usage") is a terminal disk usage analyser inspired by `ncdu`, built with TypeScript, React 19, and Ink 6. See `AGENTS.md` for the full contributor conventions (commit/PR rules, release workflow) — the essentials are summarised below.
+
+## Commands
+
+Uses `pnpm` as the package manager.
+
+```bash
+pnpm build              # tsc → dist/ (also the TypeScript error check)
+pnpm watch              # tsc in watch mode
+pnpm start -- <path>    # run node dist/cli.js (requires a build)
+pnpm test               # run all Jest tests
+pnpm test tests/state.test.ts        # run a single test file
+pnpm test -- -t "pattern"            # run tests matching a name
+pnpm lint               # eslint
+pnpm format:check       # prettier check (run before opening/updating a PR)
+pnpm format             # prettier write
+pnpm build:binary       # standalone executable via Bun (requires Bun)
+```
+
+Tests use Jest with the ts-jest ESM preset (`--experimental-vm-modules`); test files live in `tests/` as `*.test.ts(x)`. Ink components are tested with a forked `ink-testing-library`.
+
+After code changes: run `pnpm test` and `pnpm build`. Both are mandatory per `AGENTS.md`.
+
+## Architecture
+
+The project is an ESM package (`"type": "module"`): relative imports in `src/` use `.js` extensions even for `.ts`/`.tsx` files.
+
+Data flow: `cli.tsx` (commander arg parsing, alternate-screen-buffer setup, SIGTSTP/SIGCONT handling) renders `App.tsx`, which owns the scan lifecycle and all overlay/modal state, dispatching to presentational components.
+
+- **`src/App.tsx`** (~1000 lines) — central orchestrator. Runs the scan, wires keybindings via `useInput`, manages themes/config/units, tracks terminal dimensions, and coordinates every modal (help, info, settings, delete confirmation, review filters) plus the status panel and focus timer.
+- **`src/scanner.ts`** — async recursive filesystem scan producing a `FileNode` tree (parent links, `isVirtualRoot` when scanning multiple paths). Has its own inline `p-limit` for concurrency, progress + partial-result callbacks (incremental UI updates), and cancellation via `ScanCancelledError`.
+- **`src/state.ts`** — `useFileSystem` hook: navigation (`findNodeByPath`), selection, sorting, view mode (`flat` | `tree` | `review`), and per-root review state.
+- **`src/review/`** — Review mode logic as pure functions, composed as a pipeline: `derive` → `filter` → `sort` → `group` → `rows`, with `presets`, `defaults`, and `types`. This is the most unit-tested area (`tests/review.*.test.ts`).
+- **`src/keys.ts`** — declarative `ACTIONS` map (key/input bindings) checked with `checkInput`; add new keybindings here, not inline in components.
+- **`src/components/`** — presentational Ink components (FileList, ReviewList, StatusPanel, modals, etc.).
+- **`src/config.ts`** — persistent user settings via `conf` (theme, units, file type colours, heatmap, hidden files).
+- **`src/themes.ts`** / **`src/fileTypeColours.ts`** — colour palettes and file-category colour mapping.
+
+## Conventions (from AGENTS.md)
+
+- **Canadian spelling** in UI strings, variables, and comments ("colour", "centre", "behaviour").
+- **Conventional Commits** (`feat:`, `fix:`, `docs:`, `test:` — use `test:` for test-only changes, even fixes to tests). PR titles are human-readable, with **no** Conventional Commit prefix, and every PR needs at least one release-note category label.
+- **Licence headers**: new or substantially rewritten `.ts`/`.tsx`/`.js` files in `src/` and `tests/` start with a one-line summary comment followed by `(c) Copyright 2026 Liminal HQ, Scott Morris` and `SPDX-License-Identifier: MIT` (see existing files for the exact format). Do not add headers to config files, docs, or generated output.
+- **Docs sync**: user-facing behaviour, CLI options, or feature changes must be reflected in `README.md`, `SPEC.md`, and `man/smdu.1`.
+- **Git**: never push (especially force-push) unless explicitly asked; no squash merges unless requested.
+- **Releases**: follow the release workflow in `AGENTS.md` (branch `chore/release-v<version>`, sync `package.json`/`man/smdu.1`/`docs/releases/`, annotated `v*` tags).

--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -1,0 +1,16 @@
+# Integrations
+
+## Midnight Commander
+
+`docs/integrations/smdu-mc.ini` is a Midnight Commander skin derived from SMDU's default palette.
+It uses ASCII-style panel dividers for the main layout and box-drawing lines for dialogs/modals.
+
+To use it locally:
+
+```bash
+mkdir -p ~/.config/mc/skins
+cp docs/integrations/smdu-mc.ini ~/.config/mc/skins/smdu.ini
+mc -S smdu
+```
+
+If your terminal supports true colour, leave `COLORTERM=truecolor` (or `24bit`) enabled for the closest match.

--- a/docs/integrations/smdu-mc.ini
+++ b/docs/integrations/smdu-mc.ini
@@ -1,0 +1,195 @@
+[skin]
+    description = SMDU-inspired Midnight Commander skin
+    truecolors = true
+
+[Lines]
+    # Alternate panel line set matching the earlier Unicode variant:
+    # horiz = ─
+    # vert = │
+    # lefttop = ┌
+    # righttop = ┐
+    # leftbottom = └
+    # rightbottom = ┘
+    # topmiddle = ┬
+    # bottommiddle = ┴
+    # leftmiddle = ├
+    # rightmiddle = ┤
+    # cross = ┼
+    horiz = -
+    vert = |
+    lefttop = +
+    righttop = +
+    leftbottom = +
+    rightbottom = +
+    topmiddle = +
+    bottommiddle = +
+    leftmiddle = +
+    rightmiddle = +
+    cross = +
+    # Alternate dialog/modal line set matching the earlier Unicode variant:
+    # dhoriz = ─
+    # dvert = │
+    # dlefttop = ┌
+    # drighttop = ┐
+    # dleftbottom = └
+    # drightbottom = ┘
+    # dtopmiddle = ┬
+    # dbottommiddle = ┴
+    # dleftmiddle = ├
+    # drightmiddle = ┤
+    dhoriz = ─
+    dvert = │
+    dlefttop = ┌
+    drighttop = ┐
+    dleftbottom = └
+    drightbottom = ┘
+    dtopmiddle = ┬
+    dbottommiddle = ┴
+    dleftmiddle = ├
+    drightmiddle = ┤
+
+[aliases]
+    Bg = #1b1f24
+    Surface = #2a3340
+    SurfaceFocus = #334154
+    SurfaceEdge = #2e3540
+    Text = #d2d8e1
+    TextStrong = #e6ebf2
+    Muted = #7c8796
+    Header = #9aa4b2
+    Accent = #5aa2ff
+    Success = #2ec66a
+    Warning = #ffd166
+    Media = #ffb454
+    Code = #7dd3fc
+    Script = #86efac
+    Archive = #c4a7e7
+    Danger = #fca5a5
+    DangerBg = #6b2e36
+    InputBg = #222a33
+    ShadowBg = #111418
+
+[core]
+    _default_ = Text;Bg
+    selected = TextStrong;Surface;bold
+    marked = Warning;;bold
+    markselect = Warning;Surface;bold
+    gauge = TextStrong;SurfaceEdge
+    input = TextStrong;InputBg
+    inputunchanged = Muted;InputBg
+    inputmark = Bg;Accent
+    disabled = Muted;Surface
+    reverse = Bg;Accent
+    commandlinemark = Bg;Accent
+    header = Header;;bold
+    shadow = #000000;ShadowBg
+
+[dialog]
+    _default_ = Text;Surface
+    dfocus = TextStrong;SurfaceFocus
+    dhotnormal = Accent
+    dhotfocus = Accent;SurfaceFocus
+    dtitle = TextStrong;;bold
+
+[error]
+    _default_ = TextStrong;DangerBg
+    errdfocus = Bg;Danger
+    errdhotnormal = Warning
+    errdhotfocus = Bg;Danger
+    errdtitle = Warning;;bold
+
+[filehighlight]
+    directory = Accent;;bold
+    executable = Script
+    symlink = Code
+    hardlink =
+    stalelink = Danger
+    device = Archive
+    special = Header
+    core = Danger
+    temp = Muted
+    archive = Archive
+    doc = Warning
+    source = Code
+    media = Media
+    graph = Success
+    database = Header
+
+[menu]
+    _default_ = Text;Surface
+    menusel = TextStrong;SurfaceFocus
+    menuhot = Accent
+    menuhotsel = Accent;SurfaceFocus
+    menuinactive = Muted
+
+[popupmenu]
+    _default_ = Text;Surface
+    menusel = TextStrong;SurfaceFocus
+    menutitle = TextStrong;;bold
+
+[buttonbar]
+    hotkey = Bg;Accent
+    button = TextStrong;Surface
+
+[statusbar]
+    _default_ = TextStrong;SurfaceFocus
+
+[help]
+    _default_ = Text;Surface
+    helpitalic = Muted;;italic
+    helpbold = TextStrong;;bold
+    helplink = Accent;;underline
+    helpslink = Bg;Accent
+    helptitle = TextStrong;;bold
+
+[editor]
+    _default_ = Text;Bg
+    editbold = TextStrong;;bold
+    editmarked = TextStrong;Surface
+    editwhitespace = Muted;Bg
+    editnonprintable = SurfaceEdge;Bg
+    editlinestate = TextStrong;SurfaceFocus
+    bookmark = Bg;Warning
+    bookmarkfound = Bg;Success
+    editrightmargin = SurfaceEdge;Bg
+    editbg = ;Bg
+    editframe = Muted
+    editframeactive = Accent
+    editframedrag = Warning
+
+[viewer]
+    _default_ = Text;Bg
+    viewbold = TextStrong;;bold
+    viewunderline = Accent;;underline
+    viewselected = TextStrong;Surface
+
+[diffviewer]
+    added = Bg;Success
+    changedline = TextStrong;Surface
+    changednew = Bg;Accent
+    changed = TextStrong;Warning
+    removed = TextStrong;DangerBg
+    error = TextStrong;DangerBg
+
+[widget-panel]
+    sort-up-char = ↑
+    sort-down-char = ↓
+    hiddenfiles-show-char = •
+    hiddenfiles-hide-char = ○
+    history-prev-item-char = ←
+    history-next-item-char = →
+    history-show-list-char = ↓
+    filename-scroll-left-char = «
+    filename-scroll-right-char = »
+
+[widget-scrollbar]
+    first-vert-char = ↑
+    last-vert-char = ↓
+    first-horiz-char = «
+    last-horiz-char = »
+    current-char = ■
+    background-char = ▒
+
+[widget-editor]
+    window-state-char = ↕
+    window-close-char = ✕


### PR DESCRIPTION
## Summary

- **Added `CLAUDE.md`**: a codebase guide for Claude Code covering build/test/lint commands and the scan → state → review-mode pipeline architecture.
- **Synced `AGENTS.md`** against the Liminal HQ org house rules (checked `.github`, `spindle`, `threshold`, and `emoji-nook`):
  - **PR labels**: replaced stale Conventional-Commit-style aliases (`feat`, `fix`, `bugfix`, `docs`, `test`) with the org-standard categories (`enhancement`, `bug`, `documentation`, `testing`, `ci`, `build`, `chore`) — this now matches the labels actually configured on this repo.
  - **PR content**: added the `## Summary` / `## Test plan` description format and the "open ready for review by default" rule.
  - **Git workflow**: noted the `gh` CLI preference for GitHub work.
  - **Licence headers**: noted that an existing file missing a header should get one when touched.
  - **Testing**: requires saying so plainly when verification is incomplete or blocked.

### Documentation

Intentionally left the SPDX identifier as `MIT` (not `Apache-2.0 OR MIT` used by some sibling repos) since this repo's `LICENSE` and `package.json` are MIT-only.

## Test plan

- [x] Diffed against org-level `AGENTS.md` files (`.github`, `spindle`, `threshold`, `emoji-nook`) to confirm alignment
- [x] Verified actual GitHub labels on `liminal-hq/smdu` via `gh label list` to confirm the label-name fix matches reality
- [ ] No code changes; `pnpm test`/`pnpm build` not run (docs-only change)