### PR TITLE
Fix right-arrow navigation not entering folders under fragmented terminal input

### DIFF
--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -9,6 +9,7 @@ import { render } from 'ink';
 import { Command } from 'commander';
 import { App } from './App.js';
 import { VERSION } from './version.js';
+import { StdinEscapeBuffer } from './stdinEscapeBuffer.js';
 
 const program = new Command();
 
@@ -54,6 +55,7 @@ program
 				units={options.units}
 				onSuspend={handleSuspend}
 			/>,
+			{ stdin: new StdinEscapeBuffer(process.stdin) as unknown as NodeJS.ReadStream },
 		);
 
 		if (shouldUseAltBuffer) {

--- a/src/stdinEscapeBuffer.ts
+++ b/src/stdinEscapeBuffer.ts
@@ -1,0 +1,93 @@
+// Reassemble split ANSI escape sequences from stdin before Ink parses them
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: MIT
+
+import { Readable } from 'stream';
+
+const ESCAPE_BYTE = 0x1b;
+
+/**
+ * Terminal input can deliver a multi-byte escape sequence (e.g. the right arrow
+ * key's `\x1b[C`) split across separate reads under real-world conditions such as
+ * SSH/tmux/mosh latency. Ink's keypress parser treats a lone `\x1b` byte as a
+ * standalone Escape keypress with no way to know more bytes are coming, which
+ * causes bound actions (e.g. quit-on-escape) to fire on what was actually the
+ * start of an arrow key. This stream holds a lone leading escape byte briefly to
+ * see whether the rest of the sequence arrives, then forwards the reassembled
+ * chunk to whatever reads from it.
+ */
+export class StdinEscapeBuffer extends Readable {
+	private pendingEscape: Buffer | null = null;
+	private flushTimer: NodeJS.Timeout | null = null;
+
+	constructor(
+		private readonly source: NodeJS.ReadStream,
+		private readonly holdMs = 50,
+	) {
+		super();
+	}
+
+	private readonly onData = (chunk: Buffer | string): void => {
+		const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+
+		if (this.pendingEscape) {
+			const combined = Buffer.concat([this.pendingEscape, buffer]);
+			this.clearPending();
+			this.push(combined);
+			return;
+		}
+
+		if (buffer.length === 1 && buffer[0] === ESCAPE_BYTE) {
+			this.pendingEscape = buffer;
+			this.flushTimer = setTimeout(() => this.flushPending(), this.holdMs);
+			return;
+		}
+
+		this.push(buffer);
+	};
+
+	private flushPending(): void {
+		if (this.pendingEscape) {
+			this.push(this.pendingEscape);
+		}
+		this.clearPending();
+	}
+
+	private clearPending(): void {
+		if (this.flushTimer) {
+			clearTimeout(this.flushTimer);
+		}
+		this.flushTimer = null;
+		this.pendingEscape = null;
+	}
+
+	override _read(): void {
+		// No-op: data is pushed as it arrives from `onData`.
+	}
+
+	get isTTY(): boolean | undefined {
+		return this.source.isTTY;
+	}
+
+	setRawMode(mode: boolean): this {
+		this.source.setRawMode?.(mode);
+		if (mode) {
+			this.source.on('data', this.onData);
+		} else {
+			this.source.removeListener('data', this.onData);
+			this.flushPending();
+		}
+		return this;
+	}
+
+	ref(): this {
+		this.source.ref?.();
+		return this;
+	}
+
+	unref(): this {
+		this.source.unref?.();
+		return this;
+	}
+}

--- a/tests/stdinEscapeBuffer.test.ts
+++ b/tests/stdinEscapeBuffer.test.ts
@@ -1,0 +1,97 @@
+// Unit tests for reassembling split ANSI escape sequences from stdin
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it, jest, afterEach } from '@jest/globals';
+import { EventEmitter } from 'events';
+import { StdinEscapeBuffer } from '../src/stdinEscapeBuffer.js';
+
+const createFakeSource = () => {
+	const emitter = new EventEmitter() as EventEmitter & Partial<NodeJS.ReadStream>;
+	emitter.isTTY = true;
+	emitter.setRawMode = jest.fn();
+	emitter.ref = jest.fn();
+	emitter.unref = jest.fn();
+	return emitter as EventEmitter &
+		Pick<NodeJS.ReadStream, 'isTTY' | 'setRawMode' | 'ref' | 'unref'>;
+};
+
+const readAllChunks = (stream: StdinEscapeBuffer): Buffer[] => {
+	const chunks: Buffer[] = [];
+	let chunk;
+	while ((chunk = stream.read()) !== null) {
+		chunks.push(chunk);
+	}
+	return chunks;
+};
+
+describe('StdinEscapeBuffer', () => {
+	afterEach(() => {
+		jest.useRealTimers();
+	});
+
+	it('forwards non-escape input immediately', () => {
+		const source = createFakeSource();
+		const stdin = new StdinEscapeBuffer(source, 50);
+		stdin.setRawMode(true);
+
+		source.emit('data', Buffer.from('j'));
+
+		expect(readAllChunks(stdin)).toEqual([Buffer.from('j')]);
+	});
+
+	it('reassembles an escape sequence split across two reads', () => {
+		jest.useFakeTimers();
+		const source = createFakeSource();
+		const stdin = new StdinEscapeBuffer(source, 50);
+		stdin.setRawMode(true);
+
+		source.emit('data', Buffer.from([0x1b]));
+		expect(readAllChunks(stdin)).toEqual([]); // held, not yet forwarded
+
+		jest.advanceTimersByTime(10);
+		source.emit('data', Buffer.from('[C'));
+
+		expect(readAllChunks(stdin)).toEqual([Buffer.from('\x1b[C')]);
+	});
+
+	it('flushes a lone escape byte as a real Escape keypress after the hold window', () => {
+		jest.useFakeTimers();
+		const source = createFakeSource();
+		const stdin = new StdinEscapeBuffer(source, 50);
+		stdin.setRawMode(true);
+
+		source.emit('data', Buffer.from([0x1b]));
+		expect(readAllChunks(stdin)).toEqual([]);
+
+		jest.advanceTimersByTime(50);
+
+		expect(readAllChunks(stdin)).toEqual([Buffer.from([0x1b])]);
+	});
+
+	it('flushes a pending escape byte immediately when raw mode is disabled', () => {
+		jest.useFakeTimers();
+		const source = createFakeSource();
+		const stdin = new StdinEscapeBuffer(source, 50);
+		stdin.setRawMode(true);
+
+		source.emit('data', Buffer.from([0x1b]));
+		stdin.setRawMode(false);
+
+		expect(readAllChunks(stdin)).toEqual([Buffer.from([0x1b])]);
+		expect(source.setRawMode).toHaveBeenCalledWith(false);
+	});
+
+	it('proxies isTTY, ref, and unref to the underlying source', () => {
+		const source = createFakeSource();
+		const stdin = new StdinEscapeBuffer(source, 50);
+
+		expect(stdin.isTTY).toBe(true);
+		stdin.ref();
+		stdin.unref();
+
+		expect(source.ref).toHaveBeenCalled();
+		expect(source.unref).toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## Summary

- Terminal input can deliver a multi-byte escape sequence (e.g. the right arrow key's `\x1b[C`) split across separate reads under real-world conditions such as SSH/tmux/mosh latency
- Ink's keypress parser has no way to know more bytes are coming, so it parses a lone leading `\x1b` byte as a standalone Escape keypress, which triggers smdu's quit-on-escape binding before the rest of the sequence arrives — from the user's side this looks like the arrow key doing nothing (or the app exiting) instead of navigating into the selected folder
- Adds `StdinEscapeBuffer`, a small stream wrapper between `process.stdin` and Ink, that holds a lone leading escape byte for 50ms to see whether the rest of the sequence follows, reassembling it if so; a genuine standalone Escape press still quits, just ~50ms later
- Root cause was confirmed by reproduction: driving the built CLI through a real pty with an artificially fragmented right-arrow sequence reliably killed the app before the fix, and navigated correctly after

Closes #92

## Test plan

- [x] `pnpm build`
- [x] `pnpm test` (26 suites, 103 passed / 2 pre-existing skips) — includes new `tests/stdinEscapeBuffer.test.ts` covering reassembly, timeout-based flush, flush-on-rawmode-disable, and stream proxying
- [x] `pnpm lint`
- [x] Manually reproduced the original bug via a real pty with a split `\x1b[C` write — confirmed the app exited before the fix
- [x] Re-ran the same repro with the fix applied and a realistic ~5ms fragmentation gap — navigation now works correctly, no crash
- [x] Confirmed a genuine standalone Escape keypress still quits the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)
