### PR TITLE
Document multi-path scanning support

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,14 @@ Or specify a path:
 smdu /var/log
 ```
 
+You can also scan multiple paths at once:
+
+```bash
+smdu /var/log /var/cache
+```
+
+SMDU combines the given paths under a virtual root (labelled with their names) so you can compare disk usage across unrelated directories in a single session.
+
 ### Options
 
 - `--theme <name>`: Choose a theme (default, classic, dracula). This overrides the configuration file.

--- a/SPEC.md
+++ b/SPEC.md
@@ -23,6 +23,7 @@ Windows release packaging must produce MSI installer artefacts for supported arc
 ## Features
 
 - **Directory Scanning:** Recursively scans directories to calculate file sizes.
+- **Multi-Path Scanning:** Accepts multiple path arguments (`smdu /var/log /var/cache`) and combines them under a single virtual root labelled with their basenames, so unrelated directories can be compared in one session.
 - **Visual Interface:** Displays a file tree with size bars and percentages.
 - **Navigation:** Navigate through directories using arrow keys (Up/Down to move, Right/Enter to enter, Left/Backspace to go up).
 - **Sorting:** Sort files by name or size.

--- a/man/smdu.1
+++ b/man/smdu.1
@@ -3,11 +3,12 @@
 smdu \- See My Disk Usage - A clone of ncdu
 .SH SYNOPSIS
 .B smdu
-[\fIpath\fR] [\fIoptions\fR]
+[\fIpath\fR ...] [\fIoptions\fR]
 .SH DESCRIPTION
 .B smdu
 is a TUI disk usage analyser inspired by \fBncdu\fR(1). It recursively scans directories to calculate file sizes and displays them in an interactive file tree. The header shows the current path with a right-aligned \fBsmdu\fR version label. It features various view modes, sorting options, theming, and a focus timer.
 Review mode adds an analysis-first view with ranked and grouped descendants under the current root.
+Multiple paths may be given (\fBsmdu /var/log /var/cache\fR); they are combined under a single virtual root labelled with their basenames so unrelated directories can be compared in one session.
 .SH OPTIONS
 .TP
 .BR \-t ", " \-\-theme " \fItheme\fR"


### PR DESCRIPTION
## Summary
- `smdu` has accepted multiple positional path arguments since #97 (scanning them together under a virtual root), but README.md, SPEC.md, and man/smdu.1 only ever documented a single path
- Adds a short multi-path usage example to README, a Features bullet in SPEC, and updates the man page SYNOPSIS/DESCRIPTION accordingly

## Test plan
- [x] `pnpm build`
- [x] `pnpm lint`
- [x] `pnpm format:check`
- [x] `pnpm test`